### PR TITLE
Rewrite Cobertura parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # Code coverage model 
 
-[![CI on all platforms](https://github.com/uhafner/coverage-model/workflows/GitHub%20CI/badge.svg?branch=main)](https://github.com/jenkinsci/analysis-model/actions)
+[![CI on all platforms](https://github.com/uhafner/coverage-model/workflows/GitHub%20CI/badge.svg?branch=main)](https://github.com/jenkinsci/analysis-model/actions/workflows/ci.yml)
 [![Codecov](https://codecov.io/gh/uhafner/coverage-model/branch/main/graph/badge.svg)](https://codecov.io/gh/uhafner/coverage-model)
-[![LGTM grade](https://img.shields.io/lgtm/grade/java/g/uhafner/coverage-model.svg?logo=lgtm&logoWidth=18&label=lgtm%20grade)](https://lgtm.com/projects/g/uhafner/coverage-model/context:java)
-[![Total alerts](https://img.shields.io/lgtm/alerts/g/uhafner/coverage-model.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/uhafner/coverage-model/alerts/)
+[![CodeQL](https://github.com/uhafner/coverage-model/workflows/CodeQL/badge.svg?branch=main)](https://github.com/jenkinsci/analysis-model/actions/workflows/codeql.yml)
 
 Provides a Java API to parse and collect code coverage results. This API is a companion module for the 
 [Static Analysis Model and Parsers Library](https://github.com/jenkinsci/analysis-model) that does the same kind

--- a/src/main/java/edu/hm/hafner/metric/Node.java
+++ b/src/main/java/edu/hm/hafner/metric/Node.java
@@ -33,6 +33,8 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 public abstract class Node implements Serializable {
     private static final long serialVersionUID = -6608885640271135273L;
 
+    private static final String EMPTY_NAME = "-";
+    private static final String SLASH = "/";
     static final String ROOT = "^";
 
     /**
@@ -98,22 +100,20 @@ public abstract class Node implements Serializable {
     }
 
     protected String mergePath(final String localPath) {
-        // default packages are named '-' at the moment
-        if ("-".equals(localPath)) {
+        if (EMPTY_NAME.equals(localPath)) {
             return StringUtils.EMPTY;
         }
 
         if (hasParent()) {
             String parentPath = getParent().getPath();
 
-            String slash = "/";
-            if (StringUtils.isBlank(parentPath) || parentPath.equals(slash) || localPath.startsWith(parentPath + slash)) {
+            if (StringUtils.isBlank(parentPath) || parentPath.equals(SLASH) || localPath.startsWith(parentPath + SLASH)) {
                 return localPath;
             }
             if (StringUtils.isBlank(localPath)) {
                 return parentPath;
             }
-            return parentPath + slash + localPath;
+            return parentPath + SLASH + localPath;
         }
 
         return localPath;

--- a/src/main/java/edu/hm/hafner/metric/Node.java
+++ b/src/main/java/edu/hm/hafner/metric/Node.java
@@ -106,13 +106,14 @@ public abstract class Node implements Serializable {
         if (hasParent()) {
             String parentPath = getParent().getPath();
 
-            if (StringUtils.isBlank(parentPath)) {
+            String slash = "/";
+            if (StringUtils.isBlank(parentPath) || parentPath.equals(slash) || localPath.startsWith(parentPath + slash)) {
                 return localPath;
             }
             if (StringUtils.isBlank(localPath)) {
                 return parentPath;
             }
-            return parentPath + "/" + localPath;
+            return parentPath + slash + localPath;
         }
 
         return localPath;

--- a/src/main/java/edu/hm/hafner/metric/parser/CoberturaParser.java
+++ b/src/main/java/edu/hm/hafner/metric/parser/CoberturaParser.java
@@ -1,18 +1,17 @@
 package edu.hm.hafner.metric.parser;
 
 import java.io.Reader;
-import java.util.Optional;
+import java.util.NoSuchElementException;
+import java.util.regex.Pattern;
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.events.Attribute;
-import javax.xml.stream.events.EndElement;
 import javax.xml.stream.events.StartElement;
 import javax.xml.stream.events.XMLEvent;
 
-import org.apache.commons.lang3.StringUtils;
-
 import edu.hm.hafner.metric.ClassNode;
+import edu.hm.hafner.metric.Coverage;
 import edu.hm.hafner.metric.Coverage.CoverageBuilder;
 import edu.hm.hafner.metric.CyclomaticComplexity;
 import edu.hm.hafner.metric.FileNode;
@@ -29,14 +28,23 @@ import edu.hm.hafner.util.SecureXmlParserFactory.ParsingException;
  * Parses Cobertura report formats into a hierarchical Java Object Model.
  *
  * @author Melissa Bauer
+ * @author Ullrich Hafner
  */
 @SuppressWarnings("checkstyle:ClassDataAbstractionCoupling")
-public class CoberturaParser extends XmlParser {
+public class CoberturaParser extends CoverageParser {
     private static final long serialVersionUID = -3625341318291829577L;
+
+    private static final QName SOURCE = new QName("source");
+    private static final QName PACKAGE = new QName("package");
+    private static final QName CLASS = new QName("class");
+    private static final QName METHOD = new QName("method");
+    private static final QName LINE = new QName("line");
+
+    private static final Pattern BRANCH_PATTERN = Pattern.compile(".*(\\d+)/(\\d+)\\)");
 
     /** Required attributes of the XML elements. */
     private static final QName NAME = new QName("name");
-    private static final QName SOURCE_FILE_NAME = new QName("filename");
+    private static final QName FILE_NAME = new QName("filename");
     private static final QName SIGNATURE = new QName("signature");
     private static final QName HITS = new QName("hits");
     private static final QName COMPLEXITY = new QName("complexity");
@@ -46,258 +54,181 @@ public class CoberturaParser extends XmlParser {
     private static final QName BRANCH = new QName("branch");
     private static final QName CONDITION_COVERAGE = new QName("condition-coverage");
 
-    private static final String OPTIONAL_COBERTURA_ATTRIBUTE = "complexity";
 
-    private FileNode currentFileNode;
-    private Node currentNode;
-
-    private int linesCovered = 0;
-    private int linesMissed = 0;
-    private int branchesCovered = 0;
-    private int branchesMissed = 0;
-    private boolean isSource;
-
+    /**
+     * Parses the Cobertura report. The report is expected to be in XML format.
+     *
+     * @param reader
+     *         the reader to wrap
+     */
     @Override
     public ModuleNode parse(final Reader reader) {
-        SecureXmlParserFactory factory = new SecureXmlParserFactory();
-
-        XMLEventReader r;
         try {
-            r = factory.createXmlEventReader(reader);
-            while (r.hasNext()) {
-                XMLEvent e = r.nextEvent();
+            SecureXmlParserFactory factory = new SecureXmlParserFactory();
+            XMLEventReader eventReader = factory.createXmlEventReader(reader);
+            var root = new ModuleNode("-");
+            boolean isEmpty = true;
+            while (eventReader.hasNext()) {
+                XMLEvent event = eventReader.nextEvent();
 
-                if (e.isStartElement()) {
-                    startElement(e.asStartElement());
+                if (event.isStartElement()) {
+                    var startElement = event.asStartElement();
+                    var tagName = startElement.getName();
+                    if (SOURCE.equals(tagName)) {
+                        readSource(eventReader, root);
+                    }
+                    else if (PACKAGE.equals(startElement.getName())) {
+                        readPackage(eventReader, root, startElement);
+                        isEmpty = false;
+                    }
                 }
+            }
+            if (isEmpty) {
+                throw new NoSuchElementException("No coverage information found in the specified file.");
+            }
+            return root;
+        }
+        catch (XMLStreamException exception) {
+            throw new ParsingException(exception);
+        }
+    }
 
-                if (isSource && e.isCharacters()) {
-                    String source = new PathUtil().getRelativePath(e.asCharacters().getData());
-                    getRootNode().addSource(source);
-                }
+    private void readPackage(final XMLEventReader reader, final ModuleNode root,
+            final StartElement startElement) throws XMLStreamException {
+        var packageName = getValueOf(startElement, NAME);
+        var packageNode = root.findPackage(packageName).orElseGet(() -> createPackage(root, packageName));
 
-                if (e.isEndElement()) {
-                    endElement(e.asEndElement());
+        while (reader.hasNext()) {
+            XMLEvent event = reader.nextEvent();
+
+            if (event.isStartElement()) {
+                var element = event.asStartElement();
+                if (CLASS.equals(element.getName())) {
+                    var fileName = getValueOf(event.asStartElement(), FILE_NAME);
+                    var file = packageNode.findFile(fileName).orElseGet(() -> createFile(packageNode, fileName));
+
+                    readClassOrMethod(reader, file, event.asStartElement());
                 }
             }
         }
-        catch (XMLStreamException ex) {
-            throw new ParsingException(ex);
-        }
-
-        return getRootNode();
     }
 
-    /**
-     * Creates a node or a leaf depending on the given element type. Ignore coverage, source and condition
-     *
-     * @param element
-     *         the complete tag element including attributes
-     */
-    @Override
-    protected void startElement(final StartElement element) {
-        String name = element.getName().toString();
-
-        switch (name) {
-            case "coverage":
-                setRootNode(new ModuleNode(""));
-                currentNode = getRootNode();
-                break;
-
-            case "source":
-                isSource = true;
-                break;
-
-            case "package":
-                PackageNode packageNode = new PackageNode(getValueOf(element, NAME));
-                getRootNode().addChild(packageNode);
-
-                currentNode = packageNode;
-                break;
-
-            case "class": // currentNode = packageNode, classNode after
-                handleClassElement(element);
-                break;
-
-            case "method": // currentNode = classNode, methodNode after
-                Node methodNode = new MethodNode(getValueOf(element, NAME), getValueOf(element, SIGNATURE));
-
-                getOptionalValueOf(element, COMPLEXITY).ifPresent(
-                        c -> methodNode.addValue(new CyclomaticComplexity(Integer.parseInt(c))));
-
-                currentNode.addChild(methodNode);
-                currentNode = methodNode;
-                break;
-
-            case "line": // currentNode = methodNode or classNode
-                handleLineElement(element);
-                break;
-
-            default:
-                break;
-        }
+    private ClassNode createClass(final FileNode fileNode, final String className) {
+        // TODO: move to file node
+        var classNode = new ClassNode(className);
+        fileNode.addChild(classNode);
+        return classNode;
     }
 
-    /**
-     * Creates a class node and saves it to a map. This is necessary because classes occur before sourcefiles in the
-     * report. But in the java model, classes are children of files.
-     *
-     * @param element
-     *         the current report element
-     */
-    private void handleClassElement(final StartElement element) {
-        final String classPath = getValueOf(element, NAME);
-        ClassNode classNode = new ClassNode(new PathUtil().getRelativePath(classPath));
+    private FileNode createFile(final PackageNode packageNode, final String fileName) {
+        // TODO: move to package node
+        var fileNode = new FileNode(fileName);
+        packageNode.addChild(fileNode);
+        return fileNode;
+    }
 
-        // Gets sourcefilename and adds class to filenode if existing. Creates filenode if not existing
-        String sourcefilePath = getValueOf(element, SOURCE_FILE_NAME);
-        String[] parts = sourcefilePath.split("/", 0);
-        String sourcefileName = parts[parts.length - 1];
+    private PackageNode createPackage(final ModuleNode moduleNode, final String fileName) {
+        // TODO: move to module node
+        var packageNode = new PackageNode(fileName);
+        moduleNode.addChild(packageNode);
+        return packageNode;
+    }
 
-        Optional<Node> potentialNode = currentNode.find(Metric.FILE, sourcefileName);
-        if (potentialNode.isPresent()) {
-            currentFileNode = (FileNode) potentialNode.get();
-            currentFileNode.addChild(classNode);
+    private Node readClassOrMethod(final XMLEventReader reader, final FileNode file,
+            final StartElement parentElement) throws XMLStreamException {
+        var lineCovered = new CoverageBuilder(Metric.LINE).setCovered(1).setMissed(0).build();
+        var lineMissed = new CoverageBuilder(Metric.LINE).setCovered(0).setMissed(1).build();
+
+        var lineCoverage = Coverage.nullObject(Metric.LINE);
+        var branchCoverage = Coverage.nullObject(Metric.BRANCH);
+
+        Node node;
+        if (CLASS.equals(parentElement.getName())) {
+            node = createClass(file, getValueOf(parentElement, NAME)); // connect the class with the file
         }
         else {
-            FileNode fileNode = new FileNode(sourcefileName);
-            fileNode.addChild(classNode);
-            currentNode.addChild(fileNode);
-            currentFileNode = fileNode;
+            node = new MethodNode(getValueOf(parentElement, NAME), getValueOf(parentElement, SIGNATURE));
         }
+        getOptionalValueOf(parentElement, COMPLEXITY).ifPresent(
+                c -> node.addValue(new CyclomaticComplexity(Math.round(Float.parseFloat(c)))));
 
-        currentNode = classNode;
+        while (reader.hasNext()) {
+            XMLEvent event = reader.nextEvent();
+
+            if (event.isStartElement()) {
+                var nextElement = event.asStartElement();
+                if (LINE.equals(nextElement.getName())) {
+                    int lineNumber = Integer.parseInt(getValueOf(nextElement, NUMBER));
+
+                    Coverage coverage;
+                    if (isBranchCoverage(nextElement)) {
+                        coverage = readBranchCoverage(nextElement);
+                        branchCoverage = branchCoverage.add(coverage);
+                    }
+                    else {
+                        int lineHits = Integer.parseInt(getValueOf(nextElement, HITS));
+                        coverage = lineHits > 0 ? lineCovered : lineMissed;
+                        lineCoverage = lineCoverage.add(coverage);
+                    }
+
+                    if (CLASS.equals(parentElement.getName())) { // Counters are stored at file level
+                        file.addCounters(lineNumber, coverage.getCovered(), coverage.getMissed());
+                    }
+                }
+                else if (METHOD.equals(nextElement.getName())) {
+                    Node methodNode = readClassOrMethod(reader, file, nextElement);
+                    node.addChild(methodNode);
+                }
+            }
+            else if (event.isEndElement()) {
+                var endElement = event.asEndElement();
+                if (CLASS.equals(endElement.getName()) || METHOD.equals(endElement.getName())) {
+                    node.addValue(lineCoverage);
+                    if (branchCoverage.isSet()) {
+                        node.addValue(branchCoverage);
+                    }
+                    return node;
+                }
+            }
+        }
+        throw new ParsingException("Unexpected end of file");
     }
 
-    /**
-     * Adds +1 to lines covered/missed and creates a new line or branch leaf for the file node.
-     *
-     * @param element
-     *         the current report element
-     */
-    private void handleLineElement(final StartElement element) {
-
-        int lineNumber = Integer.parseInt(getValueOf(element, NUMBER));
-        int lineHits = Integer.parseInt(getValueOf(element, HITS));
-
-        boolean isBranch = false;
-        Attribute branchAttribute = element.getAttributeByName(BRANCH);
+    private boolean isBranchCoverage(final StartElement line) {
+        Attribute branchAttribute = line.getAttributeByName(BRANCH);
         if (branchAttribute != null) {
-            isBranch = Boolean.parseBoolean(branchAttribute.getValue());
+            return Boolean.parseBoolean(branchAttribute.getValue());
         }
-
-        // collect line number to coverage information in "lines" part
-        if (!currentNode.getMetric().equals(Metric.METHOD)) {
-            getLineNumberToCoverage(element, lineNumber, lineHits, isBranch);
-        }
-        // only count lines/branches for method coverage
-        else {
-            computeMethodCoverage(element, lineHits, isBranch);
-        }
+        return false;
     }
 
-    private void getLineNumberToCoverage(final StartElement element, final int lineNumber, final int lineHits,
-            final boolean isBranch) {
-        var builder = new CoverageBuilder();
+    private void readSource(final XMLEventReader reader, final ModuleNode root) throws XMLStreamException {
+        var aggregatedContent = new StringBuilder();
 
-        if (isBranch) {
-            String[] coveredAllInformation = parseConditionCoverage(element);
-            int branchCounter = Integer.parseInt(coveredAllInformation[0].substring(1));
-
-            builder.setMetric(Metric.BRANCH);
-            setCoveredVsMissed(builder, branchCounter);
-
-            // FIXME: check why branches are not stored as such?
-            int covered = lineHits > 0 ? 1 : 0;
-            currentFileNode.addCounters(lineNumber, covered, 1 - covered);
-        }
-        else {
-            int covered = lineHits > 0 ? 1 : 0;
-            currentFileNode.addCounters(lineNumber, covered, 1 - covered);
-        }
-    }
-
-    private void setCoveredVsMissed(final CoverageBuilder builder, final int coveredItems) {
-        if (coveredItems > 0) {
-            builder.setCovered(1).setMissed(0);
-        }
-        else {
-            builder.setCovered(0).setMissed(1);
-        }
-    }
-
-    private void computeMethodCoverage(final StartElement element, final int lineHits, final boolean isBranch) {
-        if (!isBranch) {
-            if (lineHits > 0) {
-                linesCovered++;
+        while (true) {
+            XMLEvent event = reader.nextEvent();
+            if (event.isCharacters()) {
+                aggregatedContent.append(event.asCharacters().getData());
             }
-            else {
-                linesMissed++;
+            else if (event.isEndElement()) {
+                root.addSource(new PathUtil().getRelativePath(aggregatedContent.toString()));
+
+                return;
             }
         }
-        else {
-            String[] coveredAllInformation = parseConditionCoverage(element);
-            int covered = Integer.parseInt(coveredAllInformation[0].substring(1));
-            int all = Integer.parseInt(StringUtils.chop(coveredAllInformation[1]));
+    }
 
-            branchesCovered = branchesCovered + covered;
-            branchesMissed = branchesMissed + (all - covered);
+    private Coverage readBranchCoverage(final StartElement line) {
+        String conditionCoverageAttribute = getValueOf(line, CONDITION_COVERAGE);
+        var matcher = BRANCH_PATTERN.matcher(conditionCoverageAttribute);
+        if (matcher.matches()) {
+            var builder = new CoverageBuilder();
+            return builder.setMetric(Metric.BRANCH)
+                    .setCovered(Integer.parseInt(matcher.group(1)))
+                    .setTotal(Integer.parseInt(matcher.group(2)))
+                    .build();
         }
-    }
+        return Coverage.nullObject(Metric.BRANCH);
 
-    /**
-     * Depending on the tag, either resets the map containing the class objects or sets the current node back to the
-     * class node.
-     *
-     * @param element
-     *         current xml element
-     */
-    @Override
-    protected void endElement(final EndElement element) {
-        switch (element.getName().toString()) {
-            case "source":
-                isSource = false;
-                break;
-            case "package": // reset
-                currentNode = getRootNode();
-                break;
-
-            case "class":
-                currentNode = currentNode.getParent();
-                break;
-
-            case "method": // currentNode = methodNode, classNode after
-                // create leaves
-                var builder = new CoverageBuilder();
-                builder.setMetric(Metric.LINE).setCovered(linesCovered).setMissed(linesMissed);
-                currentNode.addValue(builder.build());
-
-                if (branchesMissed + branchesCovered > 0) {
-                    builder.setMetric(Metric.BRANCH).setCovered(branchesCovered).setMissed(branchesMissed);
-                    currentNode.addValue(builder.build());
-                }
-
-                // reset values
-                linesCovered = 0;
-                linesMissed = 0;
-                branchesCovered = 0;
-                branchesMissed = 0;
-
-                currentNode = currentNode.getParent(); // go to class node
-                break;
-            default:
-                break;
-        }
-    }
-
-    @Override
-    boolean isOptional(final String attribute) {
-        return OPTIONAL_COBERTURA_ATTRIBUTE.equals(attribute);
-    }
-
-    private String[] parseConditionCoverage(final StartElement element) {
-        String conditionCoverageAttribute = getValueOf(element, CONDITION_COVERAGE);
-        String[] conditionCoverage = conditionCoverageAttribute.split(" ", 0);
-        return conditionCoverage[1].split("/", 0);
     }
 }

--- a/src/test/resources/cobertura-lots-of-data.xml
+++ b/src/test/resources/cobertura-lots-of-data.xml
@@ -1,0 +1,4786 @@
+<?xml version="1.0"?>
+<!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-03.dtd">
+
+<coverage line-rate="0.07023176536169118" branch-rate="0.04964616562260791" version="1.9" timestamp="1240339705747">
+	<sources>
+		<source>C:/local/ant-coverage-example/src</source>
+	</sources>
+	<packages>
+		<package name="org.apache.commons.cli" line-rate="0.6283924843423799" branch-rate="0.4538216560509554" complexity="2.9107142857142856">
+			<classes>
+				<class name="org.apache.commons.cli.AlreadySelectedException" filename="org/apache/commons/cli/AlreadySelectedException.java" line-rate="1.0" branch-rate="1.0" complexity="1.0">
+					<methods>
+						<method name="&lt;init&gt;" signature="(Ljava/lang/String;)V" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="82" hits="36" branch="false"/>
+								<line number="83" hits="36" branch="false"/>
+							</lines>
+						</method>
+					</methods>
+					<lines>
+						<line number="82" hits="36" branch="false"/>
+						<line number="83" hits="36" branch="false"/>
+					</lines>
+				</class>
+				<class name="org.apache.commons.cli.BasicParser" filename="org/apache/commons/cli/BasicParser.java" line-rate="0.0" branch-rate="1.0" complexity="1.0">
+					<methods>
+						<method name="&lt;init&gt;" signature="()V" line-rate="0.0" branch-rate="1.0">
+							<lines>
+								<line number="72" hits="0" branch="false"/>
+							</lines>
+						</method>
+						<method name="flatten" signature="(Lorg/apache/commons/cli/Options;[Ljava/lang/String;Z)[Ljava/lang/String;" line-rate="0.0" branch-rate="1.0">
+							<lines>
+								<line number="91" hits="0" branch="false"/>
+							</lines>
+						</method>
+					</methods>
+					<lines>
+						<line number="72" hits="0" branch="false"/>
+						<line number="91" hits="0" branch="false"/>
+					</lines>
+				</class>
+				<class name="org.apache.commons.cli.CommandLine" filename="org/apache/commons/cli/CommandLine.java" line-rate="0.9130434782608695" branch-rate="0.9375" complexity="1.2352941176470589">
+					<methods>
+						<method name="&lt;init&gt;" signature="()V" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="89" hits="1386" branch="false"/>
+								<line number="92" hits="1386" branch="false"/>
+								<line number="95" hits="1386" branch="false"/>
+								<line number="103" hits="1386" branch="false"/>
+								<line number="104" hits="1386" branch="false"/>
+							</lines>
+						</method>
+						<method name="addArg" signature="(Ljava/lang/String;)V" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="284" hits="1152" branch="false"/>
+								<line number="285" hits="1152" branch="false"/>
+							</lines>
+						</method>
+						<method name="addOption" signature="(Lorg/apache/commons/cli/Option;)V" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="294" hits="4284" branch="false"/>
+								<line number="296" hits="4284" branch="false"/>
+								<line number="297" hits="4284" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="298" hits="108" branch="false"/>
+								<line number="301" hits="4284" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="302" hits="396" branch="false"/>
+								<line number="304" hits="3888" branch="false"/>
+								<line number="305" hits="3888" branch="false"/>
+								<line number="307" hits="4284" branch="false"/>
+							</lines>
+						</method>
+						<method name="getArgList" signature="()Ljava/util/List;" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="261" hits="972" branch="false"/>
+							</lines>
+						</method>
+						<method name="getArgs" signature="()[Ljava/lang/String;" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="250" hits="252" branch="false"/>
+								<line number="251" hits="252" branch="false"/>
+								<line number="252" hits="252" branch="false"/>
+							</lines>
+						</method>
+						<method name="getOptionObject" signature="(C)Ljava/lang/Object;" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="151" hits="108" branch="false"/>
+							</lines>
+						</method>
+						<method name="getOptionObject" signature="(Ljava/lang/String;)Ljava/lang/Object;" line-rate="1.0" branch-rate="0.5">
+							<lines>
+								<line number="136" hits="216" branch="false"/>
+								<line number="138" hits="216" branch="false"/>
+								<line number="140" hits="216" branch="true" condition-coverage="50% (1/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+									</conditions>
+								</line>
+							</lines>
+						</method>
+						<method name="getOptionValue" signature="(C)Ljava/lang/String;" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="176" hits="54" branch="false"/>
+							</lines>
+						</method>
+						<method name="getOptionValue" signature="(CLjava/lang/String;)Ljava/lang/String;" line-rate="0.0" branch-rate="1.0">
+							<lines>
+								<line number="241" hits="0" branch="false"/>
+							</lines>
+						</method>
+						<method name="getOptionValue" signature="(Ljava/lang/String;)Ljava/lang/String;" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="163" hits="882" branch="false"/>
+								<line number="164" hits="882" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+							</lines>
+						</method>
+						<method name="getOptionValue" signature="(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="226" hits="36" branch="false"/>
+								<line number="227" hits="36" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+							</lines>
+						</method>
+						<method name="getOptionValues" signature="(C)[Ljava/lang/String;" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="212" hits="144" branch="false"/>
+							</lines>
+						</method>
+						<method name="getOptionValues" signature="(Ljava/lang/String;)[Ljava/lang/String;" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="188" hits="1476" branch="false"/>
+								<line number="190" hits="1476" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="191" hits="1458" branch="false"/>
+								<line number="192" hits="1458" branch="false"/>
+								<line number="194" hits="3114" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="195" hits="1656" branch="false"/>
+								<line number="196" hits="1656" branch="false"/>
+								<line number="197" hits="1656" branch="false"/>
+								<line number="199" hits="1476" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+							</lines>
+						</method>
+						<method name="getOptions" signature="()[Lorg/apache/commons/cli/Option;" line-rate="0.0" branch-rate="1.0">
+							<lines>
+								<line number="325" hits="0" branch="false"/>
+								<line number="328" hits="0" branch="false"/>
+								<line number="331" hits="0" branch="false"/>
+							</lines>
+						</method>
+						<method name="hasOption" signature="(C)Z" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="125" hits="90" branch="false"/>
+							</lines>
+						</method>
+						<method name="hasOption" signature="(Ljava/lang/String;)Z" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="114" hits="1944" branch="false"/>
+							</lines>
+						</method>
+						<method name="iterator" signature="()Ljava/util/Iterator;" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="316" hits="18" branch="false"/>
+							</lines>
+						</method>
+					</methods>
+					<lines>
+						<line number="89" hits="1386" branch="false"/>
+						<line number="92" hits="1386" branch="false"/>
+						<line number="95" hits="1386" branch="false"/>
+						<line number="103" hits="1386" branch="false"/>
+						<line number="104" hits="1386" branch="false"/>
+						<line number="114" hits="1944" branch="false"/>
+						<line number="125" hits="90" branch="false"/>
+						<line number="136" hits="216" branch="false"/>
+						<line number="138" hits="216" branch="false"/>
+						<line number="140" hits="216" branch="true" condition-coverage="50% (1/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+							</conditions>
+						</line>
+						<line number="151" hits="108" branch="false"/>
+						<line number="163" hits="882" branch="false"/>
+						<line number="164" hits="882" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="176" hits="54" branch="false"/>
+						<line number="188" hits="1476" branch="false"/>
+						<line number="190" hits="1476" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="191" hits="1458" branch="false"/>
+						<line number="192" hits="1458" branch="false"/>
+						<line number="194" hits="3114" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="195" hits="1656" branch="false"/>
+						<line number="196" hits="1656" branch="false"/>
+						<line number="197" hits="1656" branch="false"/>
+						<line number="199" hits="1476" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="212" hits="144" branch="false"/>
+						<line number="226" hits="36" branch="false"/>
+						<line number="227" hits="36" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="241" hits="0" branch="false"/>
+						<line number="250" hits="252" branch="false"/>
+						<line number="251" hits="252" branch="false"/>
+						<line number="252" hits="252" branch="false"/>
+						<line number="261" hits="972" branch="false"/>
+						<line number="284" hits="1152" branch="false"/>
+						<line number="285" hits="1152" branch="false"/>
+						<line number="294" hits="4284" branch="false"/>
+						<line number="296" hits="4284" branch="false"/>
+						<line number="297" hits="4284" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="298" hits="108" branch="false"/>
+						<line number="301" hits="4284" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="302" hits="396" branch="false"/>
+						<line number="304" hits="3888" branch="false"/>
+						<line number="305" hits="3888" branch="false"/>
+						<line number="307" hits="4284" branch="false"/>
+						<line number="316" hits="18" branch="false"/>
+						<line number="325" hits="0" branch="false"/>
+						<line number="328" hits="0" branch="false"/>
+						<line number="331" hits="0" branch="false"/>
+					</lines>
+				</class>
+				<class name="org.apache.commons.cli.CommandLineParser" filename="org/apache/commons/cli/CommandLineParser.java" line-rate="1.0" branch-rate="1.0" complexity="1.0">
+					<methods>
+					</methods>
+					<lines>
+					</lines>
+				</class>
+				<class name="org.apache.commons.cli.GnuParser" filename="org/apache/commons/cli/GnuParser.java" line-rate="0.7407407407407407" branch-rate="0.7222222222222222" complexity="9.0">
+					<methods>
+						<method name="&lt;init&gt;" signature="()V" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="75" hits="216" branch="false"/>
+								<line number="77" hits="216" branch="false"/>
+							</lines>
+						</method>
+						<method name="flatten" signature="(Lorg/apache/commons/cli/Options;[Ljava/lang/String;Z)[Ljava/lang/String;" line-rate="0.72" branch-rate="0.7222222222222222">
+							<lines>
+								<line number="109" hits="270" branch="false"/>
+								<line number="110" hits="270" branch="false"/>
+								<line number="111" hits="270" branch="false"/>
+								<line number="113" hits="1242" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="114" hits="972" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="115" hits="18" branch="false"/>
+								<line number="116" hits="18" branch="false"/>
+								<line number="117" hits="954" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="118" hits="36" branch="false"/>
+								<line number="119" hits="918" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="120" hits="540" branch="false"/>
+								<line number="123" hits="540" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="125" hits="72" branch="false"/>
+								<line number="127" hits="72" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="128" hits="36" branch="false"/>
+								<line number="129" hits="36" branch="false"/>
+								<line number="130" hits="36" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="131" hits="18" branch="false"/>
+								<line number="132" hits="18" branch="false"/>
+								<line number="134" hits="18" branch="false"/>
+								<line number="136" hits="72" branch="false"/>
+								<line number="137" hits="468" branch="false"/>
+								<line number="139" hits="468" branch="false"/>
+								<line number="141" hits="468" branch="true" condition-coverage="75% (3/4)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+										<condition number="1" type="jump" coverage="50%"/>
+									</conditions>
+								</line>
+								<line number="142" hits="0" branch="false"/>
+								<line number="143" hits="0" branch="false"/>
+								<line number="144" hits="468" branch="true" condition-coverage="75% (3/4)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+										<condition number="1" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="146" hits="234" branch="true" condition-coverage="50% (1/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+									</conditions>
+								</line>
+								<line number="147" hits="234" branch="false"/>
+								<line number="148" hits="234" branch="false"/>
+								<line number="149" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="150" hits="0" branch="false"/>
+								<line number="151" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="152" hits="0" branch="false"/>
+								<line number="153" hits="0" branch="false"/>
+								<line number="154" hits="0" branch="false"/>
+								<line number="156" hits="0" branch="false"/>
+								<line number="158" hits="234" branch="true" condition-coverage="50% (1/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+									</conditions>
+								</line>
+								<line number="159" hits="234" branch="false"/>
+								<line number="160" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="161" hits="0" branch="false"/>
+								<line number="162" hits="0" branch="false"/>
+								<line number="163" hits="0" branch="false"/>
+								<line number="165" hits="0" branch="false"/>
+								<line number="168" hits="540" branch="false"/>
+								<line number="169" hits="378" branch="false"/>
+								<line number="172" hits="972" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="173" hits="90" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="174" hits="54" branch="false"/>
+								<line number="178" hits="270" branch="false"/>
+							</lines>
+						</method>
+						<method name="init" signature="()V" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="84" hits="270" branch="false"/>
+								<line number="85" hits="270" branch="false"/>
+							</lines>
+						</method>
+					</methods>
+					<lines>
+						<line number="75" hits="216" branch="false"/>
+						<line number="77" hits="216" branch="false"/>
+						<line number="84" hits="270" branch="false"/>
+						<line number="85" hits="270" branch="false"/>
+						<line number="109" hits="270" branch="false"/>
+						<line number="110" hits="270" branch="false"/>
+						<line number="111" hits="270" branch="false"/>
+						<line number="113" hits="1242" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="114" hits="972" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="115" hits="18" branch="false"/>
+						<line number="116" hits="18" branch="false"/>
+						<line number="117" hits="954" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="118" hits="36" branch="false"/>
+						<line number="119" hits="918" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="120" hits="540" branch="false"/>
+						<line number="123" hits="540" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="125" hits="72" branch="false"/>
+						<line number="127" hits="72" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="128" hits="36" branch="false"/>
+						<line number="129" hits="36" branch="false"/>
+						<line number="130" hits="36" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="131" hits="18" branch="false"/>
+						<line number="132" hits="18" branch="false"/>
+						<line number="134" hits="18" branch="false"/>
+						<line number="136" hits="72" branch="false"/>
+						<line number="137" hits="468" branch="false"/>
+						<line number="139" hits="468" branch="false"/>
+						<line number="141" hits="468" branch="true" condition-coverage="75% (3/4)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+								<condition number="1" type="jump" coverage="50%"/>
+							</conditions>
+						</line>
+						<line number="142" hits="0" branch="false"/>
+						<line number="143" hits="0" branch="false"/>
+						<line number="144" hits="468" branch="true" condition-coverage="75% (3/4)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+								<condition number="1" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="146" hits="234" branch="true" condition-coverage="50% (1/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+							</conditions>
+						</line>
+						<line number="147" hits="234" branch="false"/>
+						<line number="148" hits="234" branch="false"/>
+						<line number="149" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="150" hits="0" branch="false"/>
+						<line number="151" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="152" hits="0" branch="false"/>
+						<line number="153" hits="0" branch="false"/>
+						<line number="154" hits="0" branch="false"/>
+						<line number="156" hits="0" branch="false"/>
+						<line number="158" hits="234" branch="true" condition-coverage="50% (1/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+							</conditions>
+						</line>
+						<line number="159" hits="234" branch="false"/>
+						<line number="160" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="161" hits="0" branch="false"/>
+						<line number="162" hits="0" branch="false"/>
+						<line number="163" hits="0" branch="false"/>
+						<line number="165" hits="0" branch="false"/>
+						<line number="168" hits="540" branch="false"/>
+						<line number="169" hits="378" branch="false"/>
+						<line number="172" hits="972" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="173" hits="90" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="174" hits="54" branch="false"/>
+						<line number="178" hits="270" branch="false"/>
+					</lines>
+				</class>
+				<class name="org.apache.commons.cli.HelpFormatter" filename="org/apache/commons/cli/HelpFormatter.java" line-rate="0.5032258064516129" branch-rate="0.2653061224489796" complexity="3.0">
+					<methods>
+						<method name="&lt;init&gt;" signature="()V" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="134" hits="18" branch="false"/>
+								<line number="135" hits="18" branch="false"/>
+								<line number="136" hits="18" branch="false"/>
+								<line number="137" hits="18" branch="false"/>
+								<line number="138" hits="18" branch="false"/>
+								<line number="139" hits="18" branch="false"/>
+								<line number="140" hits="18" branch="false"/>
+								<line number="141" hits="18" branch="false"/>
+								<line number="142" hits="18" branch="false"/>
+								<line number="143" hits="18" branch="false"/>
+							</lines>
+						</method>
+						<method name="createPadding" signature="(I)Ljava/lang/String;" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="634" hits="36" branch="false"/>
+								<line number="635" hits="108" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="636" hits="72" branch="false"/>
+								<line number="638" hits="36" branch="false"/>
+							</lines>
+						</method>
+						<method name="findWrapPos" signature="(Ljava/lang/String;II)I" line-rate="0.2857142857142857" branch-rate="0.1">
+							<lines>
+								<line number="595" hits="36" branch="false"/>
+								<line number="597" hits="36" branch="true" condition-coverage="25% (2/8)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+										<condition number="1" type="jump" coverage="0%"/>
+										<condition number="2" type="jump" coverage="50%"/>
+										<condition number="3" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="599" hits="0" branch="false"/>
+								<line number="600" hits="36" branch="true" condition-coverage="50% (1/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+									</conditions>
+								</line>
+								<line number="601" hits="36" branch="false"/>
+								<line number="605" hits="0" branch="false"/>
+								<line number="608" hits="0" branch="true" condition-coverage="0% (0/8)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+										<condition number="1" type="jump" coverage="0%"/>
+										<condition number="2" type="jump" coverage="0%"/>
+										<condition number="3" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="609" hits="0" branch="false"/>
+								<line number="612" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="613" hits="0" branch="false"/>
+								<line number="617" hits="0" branch="false"/>
+								<line number="619" hits="0" branch="true" condition-coverage="0% (0/8)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+										<condition number="1" type="jump" coverage="0%"/>
+										<condition number="2" type="jump" coverage="0%"/>
+										<condition number="3" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="620" hits="0" branch="false"/>
+								<line number="622" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+							</lines>
+						</method>
+						<method name="printHelp" signature="(ILjava/lang/String;Ljava/lang/String;Lorg/apache/commons/cli/Options;Ljava/lang/String;)V" line-rate="0.0" branch-rate="1.0">
+							<lines>
+								<line number="216" hits="0" branch="false"/>
+								<line number="217" hits="0" branch="false"/>
+							</lines>
+						</method>
+						<method name="printHelp" signature="(ILjava/lang/String;Ljava/lang/String;Lorg/apache/commons/cli/Options;Ljava/lang/String;Z)V" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="235" hits="18" branch="false"/>
+								<line number="236" hits="18" branch="false"/>
+								<line number="238" hits="18" branch="false"/>
+								<line number="239" hits="18" branch="false"/>
+							</lines>
+						</method>
+						<method name="printHelp" signature="(Ljava/io/PrintWriter;ILjava/lang/String;Ljava/lang/String;Lorg/apache/commons/cli/Options;IILjava/lang/String;)V" line-rate="0.0" branch-rate="1.0">
+							<lines>
+								<line number="263" hits="0" branch="false"/>
+								<line number="265" hits="0" branch="false"/>
+							</lines>
+						</method>
+						<method name="printHelp" signature="(Ljava/io/PrintWriter;ILjava/lang/String;Ljava/lang/String;Lorg/apache/commons/cli/Options;IILjava/lang/String;Z)V" line-rate="0.6363636363636364" branch-rate="0.35714285714285715">
+							<lines>
+								<line number="291" hits="18" branch="true" condition-coverage="50% (2/4)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+										<condition number="1" type="jump" coverage="50%"/>
+									</conditions>
+								</line>
+								<line number="292" hits="0" branch="false"/>
+								<line number="295" hits="18" branch="true" condition-coverage="50% (1/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+									</conditions>
+								</line>
+								<line number="296" hits="0" branch="false"/>
+								<line number="298" hits="18" branch="false"/>
+								<line number="301" hits="18" branch="true" condition-coverage="25% (1/4)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+										<condition number="1" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="302" hits="0" branch="false"/>
+								<line number="304" hits="18" branch="false"/>
+								<line number="305" hits="18" branch="true" condition-coverage="25% (1/4)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+										<condition number="1" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="306" hits="0" branch="false"/>
+								<line number="308" hits="18" branch="false"/>
+							</lines>
+						</method>
+						<method name="printHelp" signature="(Ljava/lang/String;Ljava/lang/String;Lorg/apache/commons/cli/Options;Ljava/lang/String;)V" line-rate="0.0" branch-rate="1.0">
+							<lines>
+								<line number="181" hits="0" branch="false"/>
+								<line number="182" hits="0" branch="false"/>
+							</lines>
+						</method>
+						<method name="printHelp" signature="(Ljava/lang/String;Ljava/lang/String;Lorg/apache/commons/cli/Options;Ljava/lang/String;Z)V" line-rate="0.0" branch-rate="1.0">
+							<lines>
+								<line number="198" hits="0" branch="false"/>
+								<line number="200" hits="0" branch="false"/>
+							</lines>
+						</method>
+						<method name="printHelp" signature="(Ljava/lang/String;Lorg/apache/commons/cli/Options;)V" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="153" hits="18" branch="false"/>
+								<line number="154" hits="18" branch="false"/>
+							</lines>
+						</method>
+						<method name="printHelp" signature="(Ljava/lang/String;Lorg/apache/commons/cli/Options;Z)V" line-rate="0.0" branch-rate="1.0">
+							<lines>
+								<line number="166" hits="0" branch="false"/>
+								<line number="167" hits="0" branch="false"/>
+							</lines>
+						</method>
+						<method name="printOptions" signature="(Ljava/io/PrintWriter;ILorg/apache/commons/cli/Options;II)V" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="434" hits="18" branch="false"/>
+								<line number="435" hits="18" branch="false"/>
+								<line number="436" hits="18" branch="false"/>
+								<line number="437" hits="18" branch="false"/>
+							</lines>
+						</method>
+						<method name="printUsage" signature="(Ljava/io/PrintWriter;ILjava/lang/String;)V" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="418" hits="18" branch="false"/>
+								<line number="419" hits="18" branch="false"/>
+								<line number="421" hits="18" branch="false"/>
+							</lines>
+						</method>
+						<method name="printUsage" signature="(Ljava/io/PrintWriter;ILjava/lang/String;Lorg/apache/commons/cli/Options;)V" line-rate="0.0" branch-rate="0.0">
+							<lines>
+								<line number="321" hits="0" branch="false"/>
+								<line number="325" hits="0" branch="false"/>
+								<line number="331" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="333" hits="0" branch="false"/>
+								<line number="336" hits="0" branch="false"/>
+								<line number="345" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="346" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="348" hits="0" branch="false"/>
+								<line number="351" hits="0" branch="false"/>
+								<line number="353" hits="0" branch="false"/>
+								<line number="356" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="358" hits="0" branch="false"/>
+								<line number="359" hits="0" branch="false"/>
+								<line number="362" hits="0" branch="false"/>
+								<line number="363" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="364" hits="0" branch="false"/>
+								<line number="367" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="368" hits="0" branch="false"/>
+								<line number="370" hits="0" branch="false"/>
+								<line number="371" hits="0" branch="false"/>
+								<line number="373" hits="0" branch="false"/>
+								<line number="378" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="379" hits="0" branch="false"/>
+								<line number="382" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="383" hits="0" branch="false"/>
+								<line number="385" hits="0" branch="false"/>
+								<line number="388" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="389" hits="0" branch="false"/>
+								<line number="393" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="394" hits="0" branch="false"/>
+								<line number="398" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="399" hits="0" branch="false"/>
+								<line number="401" hits="0" branch="false"/>
+								<line number="403" hits="0" branch="false"/>
+								<line number="406" hits="0" branch="false"/>
+								<line number="408" hits="0" branch="false"/>
+							</lines>
+						</method>
+						<method name="printWrapped" signature="(Ljava/io/PrintWriter;IILjava/lang/String;)V" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="460" hits="18" branch="false"/>
+								<line number="461" hits="18" branch="false"/>
+								<line number="462" hits="18" branch="false"/>
+								<line number="463" hits="18" branch="false"/>
+							</lines>
+						</method>
+						<method name="printWrapped" signature="(Ljava/io/PrintWriter;ILjava/lang/String;)V" line-rate="0.0" branch-rate="1.0">
+							<lines>
+								<line number="447" hits="0" branch="false"/>
+								<line number="448" hits="0" branch="false"/>
+							</lines>
+						</method>
+						<method name="renderOptions" signature="(Ljava/lang/StringBuffer;ILorg/apache/commons/cli/Options;II)Ljava/lang/StringBuffer;" line-rate="0.8484848484848485" branch-rate="0.6111111111111112">
+							<lines>
+								<line number="481" hits="18" branch="false"/>
+								<line number="482" hits="18" branch="false"/>
+								<line number="488" hits="18" branch="false"/>
+								<line number="490" hits="18" branch="false"/>
+								<line number="492" hits="18" branch="false"/>
+								<line number="493" hits="18" branch="false"/>
+								<line number="494" hits="18" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="495" hits="18" branch="false"/>
+								<line number="496" hits="18" branch="false"/>
+								<line number="498" hits="18" branch="true" condition-coverage="50% (1/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+									</conditions>
+								</line>
+								<line number="499" hits="0" branch="false"/>
+								<line number="502" hits="18" branch="false"/>
+								<line number="504" hits="18" branch="true" condition-coverage="50% (1/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+									</conditions>
+								</line>
+								<line number="505" hits="0" branch="false"/>
+								<line number="510" hits="18" branch="true" condition-coverage="50% (1/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+									</conditions>
+								</line>
+								<line number="511" hits="18" branch="true" condition-coverage="50% (1/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+									</conditions>
+								</line>
+								<line number="512" hits="0" branch="false"/>
+								<line number="514" hits="18" branch="false"/>
+								<line number="518" hits="18" branch="false"/>
+								<line number="519" hits="18" branch="true" condition-coverage="50% (1/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+									</conditions>
+								</line>
+								<line number="521" hits="18" branch="false"/>
+								<line number="522" hits="18" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="523" hits="18" branch="false"/>
+								<line number="524" hits="18" branch="false"/>
+								<line number="526" hits="18" branch="true" condition-coverage="50% (1/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+									</conditions>
+								</line>
+								<line number="527" hits="0" branch="false"/>
+								<line number="529" hits="18" branch="false"/>
+								<line number="531" hits="18" branch="false"/>
+								<line number="532" hits="18" branch="false"/>
+								<line number="534" hits="18" branch="true" condition-coverage="50% (1/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+									</conditions>
+								</line>
+								<line number="535" hits="0" branch="false"/>
+								<line number="537" hits="18" branch="false"/>
+								<line number="539" hits="18" branch="false"/>
+							</lines>
+						</method>
+						<method name="renderWrappedText" signature="(Ljava/lang/StringBuffer;IILjava/lang/String;)Ljava/lang/StringBuffer;" line-rate="0.3333333333333333" branch-rate="0.25">
+							<lines>
+								<line number="556" hits="36" branch="false"/>
+								<line number="557" hits="36" branch="true" condition-coverage="50% (1/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+									</conditions>
+								</line>
+								<line number="558" hits="36" branch="false"/>
+								<line number="559" hits="36" branch="false"/>
+								<line number="561" hits="0" branch="false"/>
+								<line number="566" hits="0" branch="false"/>
+								<line number="569" hits="0" branch="false"/>
+								<line number="570" hits="0" branch="false"/>
+								<line number="571" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="572" hits="0" branch="false"/>
+								<line number="573" hits="0" branch="false"/>
+								<line number="576" hits="0" branch="false"/>
+							</lines>
+						</method>
+						<method name="rtrim" signature="(Ljava/lang/String;)Ljava/lang/String;" line-rate="0.6666666666666666" branch-rate="0.5">
+							<lines>
+								<line number="649" hits="36" branch="true" condition-coverage="50% (2/4)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+										<condition number="1" type="jump" coverage="50%"/>
+									</conditions>
+								</line>
+								<line number="650" hits="0" branch="false"/>
+								<line number="653" hits="36" branch="false"/>
+								<line number="654" hits="36" branch="true" condition-coverage="50% (2/4)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+										<condition number="1" type="jump" coverage="50%"/>
+									</conditions>
+								</line>
+								<line number="655" hits="0" branch="false"/>
+								<line number="657" hits="36" branch="false"/>
+							</lines>
+						</method>
+					</methods>
+					<lines>
+						<line number="134" hits="18" branch="false"/>
+						<line number="135" hits="18" branch="false"/>
+						<line number="136" hits="18" branch="false"/>
+						<line number="137" hits="18" branch="false"/>
+						<line number="138" hits="18" branch="false"/>
+						<line number="139" hits="18" branch="false"/>
+						<line number="140" hits="18" branch="false"/>
+						<line number="141" hits="18" branch="false"/>
+						<line number="142" hits="18" branch="false"/>
+						<line number="143" hits="18" branch="false"/>
+						<line number="153" hits="18" branch="false"/>
+						<line number="154" hits="18" branch="false"/>
+						<line number="166" hits="0" branch="false"/>
+						<line number="167" hits="0" branch="false"/>
+						<line number="181" hits="0" branch="false"/>
+						<line number="182" hits="0" branch="false"/>
+						<line number="198" hits="0" branch="false"/>
+						<line number="200" hits="0" branch="false"/>
+						<line number="216" hits="0" branch="false"/>
+						<line number="217" hits="0" branch="false"/>
+						<line number="235" hits="18" branch="false"/>
+						<line number="236" hits="18" branch="false"/>
+						<line number="238" hits="18" branch="false"/>
+						<line number="239" hits="18" branch="false"/>
+						<line number="263" hits="0" branch="false"/>
+						<line number="265" hits="0" branch="false"/>
+						<line number="291" hits="18" branch="true" condition-coverage="50% (2/4)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+								<condition number="1" type="jump" coverage="50%"/>
+							</conditions>
+						</line>
+						<line number="292" hits="0" branch="false"/>
+						<line number="295" hits="18" branch="true" condition-coverage="50% (1/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+							</conditions>
+						</line>
+						<line number="296" hits="0" branch="false"/>
+						<line number="298" hits="18" branch="false"/>
+						<line number="301" hits="18" branch="true" condition-coverage="25% (1/4)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+								<condition number="1" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="302" hits="0" branch="false"/>
+						<line number="304" hits="18" branch="false"/>
+						<line number="305" hits="18" branch="true" condition-coverage="25% (1/4)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+								<condition number="1" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="306" hits="0" branch="false"/>
+						<line number="308" hits="18" branch="false"/>
+						<line number="321" hits="0" branch="false"/>
+						<line number="325" hits="0" branch="false"/>
+						<line number="331" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="333" hits="0" branch="false"/>
+						<line number="336" hits="0" branch="false"/>
+						<line number="345" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="346" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="348" hits="0" branch="false"/>
+						<line number="351" hits="0" branch="false"/>
+						<line number="353" hits="0" branch="false"/>
+						<line number="356" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="358" hits="0" branch="false"/>
+						<line number="359" hits="0" branch="false"/>
+						<line number="362" hits="0" branch="false"/>
+						<line number="363" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="364" hits="0" branch="false"/>
+						<line number="367" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="368" hits="0" branch="false"/>
+						<line number="370" hits="0" branch="false"/>
+						<line number="371" hits="0" branch="false"/>
+						<line number="373" hits="0" branch="false"/>
+						<line number="378" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="379" hits="0" branch="false"/>
+						<line number="382" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="383" hits="0" branch="false"/>
+						<line number="385" hits="0" branch="false"/>
+						<line number="388" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="389" hits="0" branch="false"/>
+						<line number="393" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="394" hits="0" branch="false"/>
+						<line number="398" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="399" hits="0" branch="false"/>
+						<line number="401" hits="0" branch="false"/>
+						<line number="403" hits="0" branch="false"/>
+						<line number="406" hits="0" branch="false"/>
+						<line number="408" hits="0" branch="false"/>
+						<line number="418" hits="18" branch="false"/>
+						<line number="419" hits="18" branch="false"/>
+						<line number="421" hits="18" branch="false"/>
+						<line number="434" hits="18" branch="false"/>
+						<line number="435" hits="18" branch="false"/>
+						<line number="436" hits="18" branch="false"/>
+						<line number="437" hits="18" branch="false"/>
+						<line number="447" hits="0" branch="false"/>
+						<line number="448" hits="0" branch="false"/>
+						<line number="460" hits="18" branch="false"/>
+						<line number="461" hits="18" branch="false"/>
+						<line number="462" hits="18" branch="false"/>
+						<line number="463" hits="18" branch="false"/>
+						<line number="481" hits="18" branch="false"/>
+						<line number="482" hits="18" branch="false"/>
+						<line number="488" hits="18" branch="false"/>
+						<line number="490" hits="18" branch="false"/>
+						<line number="492" hits="18" branch="false"/>
+						<line number="493" hits="18" branch="false"/>
+						<line number="494" hits="18" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="495" hits="18" branch="false"/>
+						<line number="496" hits="18" branch="false"/>
+						<line number="498" hits="18" branch="true" condition-coverage="50% (1/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+							</conditions>
+						</line>
+						<line number="499" hits="0" branch="false"/>
+						<line number="502" hits="18" branch="false"/>
+						<line number="504" hits="18" branch="true" condition-coverage="50% (1/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+							</conditions>
+						</line>
+						<line number="505" hits="0" branch="false"/>
+						<line number="510" hits="18" branch="true" condition-coverage="50% (1/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+							</conditions>
+						</line>
+						<line number="511" hits="18" branch="true" condition-coverage="50% (1/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+							</conditions>
+						</line>
+						<line number="512" hits="0" branch="false"/>
+						<line number="514" hits="18" branch="false"/>
+						<line number="518" hits="18" branch="false"/>
+						<line number="519" hits="18" branch="true" condition-coverage="50% (1/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+							</conditions>
+						</line>
+						<line number="521" hits="18" branch="false"/>
+						<line number="522" hits="18" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="523" hits="18" branch="false"/>
+						<line number="524" hits="18" branch="false"/>
+						<line number="526" hits="18" branch="true" condition-coverage="50% (1/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+							</conditions>
+						</line>
+						<line number="527" hits="0" branch="false"/>
+						<line number="529" hits="18" branch="false"/>
+						<line number="531" hits="18" branch="false"/>
+						<line number="532" hits="18" branch="false"/>
+						<line number="534" hits="18" branch="true" condition-coverage="50% (1/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+							</conditions>
+						</line>
+						<line number="535" hits="0" branch="false"/>
+						<line number="537" hits="18" branch="false"/>
+						<line number="539" hits="18" branch="false"/>
+						<line number="556" hits="36" branch="false"/>
+						<line number="557" hits="36" branch="true" condition-coverage="50% (1/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+							</conditions>
+						</line>
+						<line number="558" hits="36" branch="false"/>
+						<line number="559" hits="36" branch="false"/>
+						<line number="561" hits="0" branch="false"/>
+						<line number="566" hits="0" branch="false"/>
+						<line number="569" hits="0" branch="false"/>
+						<line number="570" hits="0" branch="false"/>
+						<line number="571" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="572" hits="0" branch="false"/>
+						<line number="573" hits="0" branch="false"/>
+						<line number="576" hits="0" branch="false"/>
+						<line number="595" hits="36" branch="false"/>
+						<line number="597" hits="36" branch="true" condition-coverage="25% (2/8)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+								<condition number="1" type="jump" coverage="0%"/>
+								<condition number="2" type="jump" coverage="50%"/>
+								<condition number="3" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="599" hits="0" branch="false"/>
+						<line number="600" hits="36" branch="true" condition-coverage="50% (1/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+							</conditions>
+						</line>
+						<line number="601" hits="36" branch="false"/>
+						<line number="605" hits="0" branch="false"/>
+						<line number="608" hits="0" branch="true" condition-coverage="0% (0/8)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+								<condition number="1" type="jump" coverage="0%"/>
+								<condition number="2" type="jump" coverage="0%"/>
+								<condition number="3" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="609" hits="0" branch="false"/>
+						<line number="612" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="613" hits="0" branch="false"/>
+						<line number="617" hits="0" branch="false"/>
+						<line number="619" hits="0" branch="true" condition-coverage="0% (0/8)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+								<condition number="1" type="jump" coverage="0%"/>
+								<condition number="2" type="jump" coverage="0%"/>
+								<condition number="3" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="620" hits="0" branch="false"/>
+						<line number="622" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="634" hits="36" branch="false"/>
+						<line number="635" hits="108" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="636" hits="72" branch="false"/>
+						<line number="638" hits="36" branch="false"/>
+						<line number="649" hits="36" branch="true" condition-coverage="50% (2/4)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+								<condition number="1" type="jump" coverage="50%"/>
+							</conditions>
+						</line>
+						<line number="650" hits="0" branch="false"/>
+						<line number="653" hits="36" branch="false"/>
+						<line number="654" hits="36" branch="true" condition-coverage="50% (2/4)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+								<condition number="1" type="jump" coverage="50%"/>
+							</conditions>
+						</line>
+						<line number="655" hits="0" branch="false"/>
+						<line number="657" hits="36" branch="false"/>
+					</lines>
+				</class>
+				<class name="org.apache.commons.cli.HelpFormatter$1" filename="org/apache/commons/cli/HelpFormatter.java" line-rate="1.0" branch-rate="1.0" complexity="3.0">
+					<methods>
+					</methods>
+					<lines>
+					</lines>
+				</class>
+				<class name="org.apache.commons.cli.HelpFormatter$StringBufferComparator" filename="org/apache/commons/cli/HelpFormatter.java" line-rate="0.125" branch-rate="0.0" complexity="3.0">
+					<methods>
+						<method name="&lt;init&gt;" signature="()V" line-rate="1.0" branch-rate="1.0">
+							<lines>
+							</lines>
+						</method>
+						<method name="&lt;init&gt;" signature="(Lorg/apache/commons/cli/HelpFormatter$1;)V" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="665" hits="36" branch="false"/>
+							</lines>
+						</method>
+						<method name="compare" signature="(Ljava/lang/Object;Ljava/lang/Object;)I" line-rate="0.0" branch-rate="1.0">
+							<lines>
+								<line number="675" hits="0" branch="false"/>
+								<line number="676" hits="0" branch="false"/>
+								<line number="677" hits="0" branch="false"/>
+							</lines>
+						</method>
+						<method name="stripPrefix" signature="(Ljava/lang/String;)Ljava/lang/String;" line-rate="0.0" branch-rate="0.0">
+							<lines>
+								<line number="689" hits="0" branch="false"/>
+								<line number="690" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="691" hits="0" branch="false"/>
+								<line number="693" hits="0" branch="false"/>
+							</lines>
+						</method>
+					</methods>
+					<lines>
+						<line number="665" hits="36" branch="false"/>
+						<line number="675" hits="0" branch="false"/>
+						<line number="676" hits="0" branch="false"/>
+						<line number="677" hits="0" branch="false"/>
+						<line number="689" hits="0" branch="false"/>
+						<line number="690" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="691" hits="0" branch="false"/>
+						<line number="693" hits="0" branch="false"/>
+					</lines>
+				</class>
+				<class name="org.apache.commons.cli.MissingArgumentException" filename="org/apache/commons/cli/MissingArgumentException.java" line-rate="1.0" branch-rate="1.0" complexity="1.0">
+					<methods>
+						<method name="&lt;init&gt;" signature="(Ljava/lang/String;)V" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="83" hits="54" branch="false"/>
+								<line number="84" hits="54" branch="false"/>
+							</lines>
+						</method>
+					</methods>
+					<lines>
+						<line number="83" hits="54" branch="false"/>
+						<line number="84" hits="54" branch="false"/>
+					</lines>
+				</class>
+				<class name="org.apache.commons.cli.MissingOptionException" filename="org/apache/commons/cli/MissingOptionException.java" line-rate="1.0" branch-rate="1.0" complexity="1.0">
+					<methods>
+						<method name="&lt;init&gt;" signature="(Ljava/lang/String;)V" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="82" hits="54" branch="false"/>
+								<line number="83" hits="54" branch="false"/>
+							</lines>
+						</method>
+					</methods>
+					<lines>
+						<line number="82" hits="54" branch="false"/>
+						<line number="83" hits="54" branch="false"/>
+					</lines>
+				</class>
+				<class name="org.apache.commons.cli.NumberUtils" filename="org/apache/commons/cli/NumberUtils.java" line-rate="0.12698412698412698" branch-rate="0.07239819004524888" complexity="7.2105263157894735">
+					<methods>
+						<method name="&lt;init&gt;" signature="()V" line-rate="0.0" branch-rate="1.0">
+							<lines>
+								<line number="50" hits="0" branch="false"/>
+								<line number="51" hits="0" branch="false"/>
+							</lines>
+						</method>
+						<method name="compare" signature="(DD)I" line-rate="0.0" branch-rate="0.0">
+							<lines>
+								<line number="517" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="518" hits="0" branch="false"/>
+								<line number="520" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="521" hits="0" branch="false"/>
+								<line number="527" hits="0" branch="false"/>
+								<line number="528" hits="0" branch="false"/>
+								<line number="529" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="530" hits="0" branch="false"/>
+								<line number="538" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="539" hits="0" branch="false"/>
+								<line number="541" hits="0" branch="false"/>
+							</lines>
+						</method>
+						<method name="compare" signature="(FF)I" line-rate="0.0" branch-rate="0.0">
+							<lines>
+								<line number="583" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="584" hits="0" branch="false"/>
+								<line number="586" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="587" hits="0" branch="false"/>
+								<line number="593" hits="0" branch="false"/>
+								<line number="594" hits="0" branch="false"/>
+								<line number="595" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="596" hits="0" branch="false"/>
+								<line number="604" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="605" hits="0" branch="false"/>
+								<line number="607" hits="0" branch="false"/>
+							</lines>
+						</method>
+						<method name="createBigDecimal" signature="(Ljava/lang/String;)Ljava/math/BigDecimal;" line-rate="0.0" branch-rate="1.0">
+							<lines>
+								<line number="394" hits="0" branch="false"/>
+								<line number="395" hits="0" branch="false"/>
+							</lines>
+						</method>
+						<method name="createBigInteger" signature="(Ljava/lang/String;)Ljava/math/BigInteger;" line-rate="0.0" branch-rate="1.0">
+							<lines>
+								<line number="380" hits="0" branch="false"/>
+								<line number="381" hits="0" branch="false"/>
+							</lines>
+						</method>
+						<method name="createDouble" signature="(Ljava/lang/String;)Ljava/lang/Double;" line-rate="0.0" branch-rate="1.0">
+							<lines>
+								<line number="339" hits="0" branch="false"/>
+							</lines>
+						</method>
+						<method name="createFloat" signature="(Ljava/lang/String;)Ljava/lang/Float;" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="326" hits="36" branch="false"/>
+							</lines>
+						</method>
+						<method name="createInteger" signature="(Ljava/lang/String;)Ljava/lang/Integer;" line-rate="0.0" branch-rate="1.0">
+							<lines>
+								<line number="354" hits="0" branch="false"/>
+							</lines>
+						</method>
+						<method name="createLong" signature="(Ljava/lang/String;)Ljava/lang/Long;" line-rate="0.0" branch-rate="1.0">
+							<lines>
+								<line number="367" hits="0" branch="false"/>
+							</lines>
+						</method>
+						<method name="createNumber" signature="(Ljava/lang/String;)Ljava/lang/Number;" line-rate="0.27941176470588236" branch-rate="0.16049382716049382">
+							<lines>
+								<line number="147" hits="36" branch="true" condition-coverage="50% (1/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+									</conditions>
+								</line>
+								<line number="148" hits="0" branch="false"/>
+								<line number="150" hits="36" branch="true" condition-coverage="50% (1/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+									</conditions>
+								</line>
+								<line number="151" hits="0" branch="false"/>
+								<line number="153" hits="36" branch="true" condition-coverage="50% (1/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+									</conditions>
+								</line>
+								<line number="158" hits="0" branch="false"/>
+								<line number="160" hits="36" branch="true" condition-coverage="50% (2/4)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+										<condition number="1" type="jump" coverage="50%"/>
+									</conditions>
+								</line>
+								<line number="161" hits="0" branch="false"/>
+								<line number="163" hits="36" branch="false"/>
+								<line number="167" hits="36" branch="false"/>
+								<line number="168" hits="36" branch="false"/>
+								<line number="170" hits="36" branch="true" condition-coverage="50% (1/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+									</conditions>
+								</line>
+								<line number="171" hits="36" branch="true" condition-coverage="50% (1/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+									</conditions>
+								</line>
+								<line number="172" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="173" hits="0" branch="false"/>
+								<line number="176" hits="0" branch="false"/>
+								<line number="178" hits="36" branch="false"/>
+								<line number="180" hits="36" branch="false"/>
+								<line number="182" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="183" hits="0" branch="false"/>
+								<line number="185" hits="0" branch="false"/>
+								<line number="187" hits="0" branch="false"/>
+								<line number="189" hits="36" branch="true" condition-coverage="50% (1/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+									</conditions>
+								</line>
+								<line number="190" hits="0" branch="true" condition-coverage="0% (0/4)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+										<condition number="1" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="191" hits="0" branch="false"/>
+								<line number="193" hits="0" branch="false"/>
+								<line number="196" hits="0" branch="false"/>
+								<line number="197" hits="0" branch="true" condition-coverage="0% (0/4)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+										<condition number="1" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="198" hits="0" branch="true" condition-coverage="0% (0/7)">
+									<conditions>
+										<condition number="0" type="switch" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="201" hits="0" branch="true" condition-coverage="0% (0/10)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+										<condition number="1" type="jump" coverage="0%"/>
+										<condition number="2" type="jump" coverage="0%"/>
+										<condition number="3" type="jump" coverage="0%"/>
+										<condition number="4" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="207" hits="0" branch="false"/>
+								<line number="208" hits="0" branch="false"/>
+								<line number="211" hits="0" branch="false"/>
+								<line number="213" hits="0" branch="false"/>
+								<line number="218" hits="0" branch="false"/>
+								<line number="219" hits="0" branch="true" condition-coverage="0% (0/6)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+										<condition number="1" type="jump" coverage="0%"/>
+										<condition number="2" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="225" hits="0" branch="false"/>
+								<line number="227" hits="0" branch="false"/>
+								<line number="228" hits="0" branch="false"/>
+								<line number="233" hits="0" branch="false"/>
+								<line number="234" hits="0" branch="true" condition-coverage="0% (0/6)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+										<condition number="1" type="jump" coverage="0%"/>
+										<condition number="2" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="236" hits="0" branch="false"/>
+								<line number="238" hits="0" branch="false"/>
+								<line number="239" hits="0" branch="false"/>
+								<line number="241" hits="0" branch="false"/>
+								<line number="242" hits="0" branch="false"/>
+								<line number="246" hits="0" branch="false"/>
+								<line number="252" hits="36" branch="true" condition-coverage="25% (1/4)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+										<condition number="1" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="253" hits="0" branch="false"/>
+								<line number="255" hits="36" branch="false"/>
+								<line number="257" hits="36" branch="true" condition-coverage="25% (1/4)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+										<condition number="1" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="260" hits="0" branch="false"/>
+								<line number="261" hits="0" branch="false"/>
+								<line number="264" hits="0" branch="false"/>
+								<line number="265" hits="0" branch="false"/>
+								<line number="267" hits="0" branch="false"/>
+								<line number="270" hits="36" branch="true" condition-coverage="25% (1/4)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+										<condition number="1" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="272" hits="36" branch="false"/>
+								<line number="273" hits="36" branch="true" condition-coverage="33% (2/6)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+										<condition number="1" type="jump" coverage="50%"/>
+										<condition number="2" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="275" hits="36" branch="false"/>
+								<line number="277" hits="0" branch="false"/>
+								<line number="278" hits="0" branch="false"/>
+								<line number="280" hits="0" branch="false"/>
+								<line number="281" hits="0" branch="true" condition-coverage="0% (0/6)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+										<condition number="1" type="jump" coverage="0%"/>
+										<condition number="2" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="283" hits="0" branch="false"/>
+								<line number="285" hits="0" branch="false"/>
+								<line number="286" hits="0" branch="false"/>
+								<line number="288" hits="0" branch="false"/>
+							</lines>
+						</method>
+						<method name="isAllZeros" signature="(Ljava/lang/String;)Z" line-rate="0.6666666666666666" branch-rate="0.375">
+							<lines>
+								<line number="303" hits="36" branch="true" condition-coverage="50% (1/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+									</conditions>
+								</line>
+								<line number="304" hits="0" branch="false"/>
+								<line number="306" hits="36" branch="true" condition-coverage="50% (1/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+									</conditions>
+								</line>
+								<line number="307" hits="36" branch="true" condition-coverage="50% (1/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+									</conditions>
+								</line>
+								<line number="308" hits="36" branch="false"/>
+								<line number="311" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+							</lines>
+						</method>
+						<method name="isDigits" signature="(Ljava/lang/String;)Z" line-rate="0.0" branch-rate="0.0">
+							<lines>
+								<line number="624" hits="0" branch="true" condition-coverage="0% (0/4)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+										<condition number="1" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="625" hits="0" branch="false"/>
+								<line number="627" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="628" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="629" hits="0" branch="false"/>
+								<line number="632" hits="0" branch="false"/>
+							</lines>
+						</method>
+						<method name="isNumber" signature="(Ljava/lang/String;)Z" line-rate="0.0" branch-rate="0.0">
+							<lines>
+								<line number="649" hits="0" branch="true" condition-coverage="0% (0/4)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+										<condition number="1" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="650" hits="0" branch="false"/>
+								<line number="652" hits="0" branch="false"/>
+								<line number="653" hits="0" branch="false"/>
+								<line number="654" hits="0" branch="false"/>
+								<line number="655" hits="0" branch="false"/>
+								<line number="656" hits="0" branch="false"/>
+								<line number="657" hits="0" branch="false"/>
+								<line number="659" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="660" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="661" hits="0" branch="true" condition-coverage="0% (0/4)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+										<condition number="1" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="662" hits="0" branch="false"/>
+								<line number="663" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="664" hits="0" branch="false"/>
+								<line number="667" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="668" hits="0" branch="true" condition-coverage="0% (0/12)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+										<condition number="1" type="jump" coverage="0%"/>
+										<condition number="2" type="jump" coverage="0%"/>
+										<condition number="3" type="jump" coverage="0%"/>
+										<condition number="4" type="jump" coverage="0%"/>
+										<condition number="5" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="671" hits="0" branch="false"/>
+								<line number="674" hits="0" branch="false"/>
+								<line number="677" hits="0" branch="false"/>
+								<line number="679" hits="0" branch="false"/>
+								<line number="683" hits="0" branch="true" condition-coverage="0% (0/8)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+										<condition number="1" type="jump" coverage="0%"/>
+										<condition number="2" type="jump" coverage="0%"/>
+										<condition number="3" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="684" hits="0" branch="true" condition-coverage="0% (0/4)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+										<condition number="1" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="685" hits="0" branch="false"/>
+								<line number="686" hits="0" branch="false"/>
+								<line number="687" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="688" hits="0" branch="true" condition-coverage="0% (0/4)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+										<condition number="1" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="690" hits="0" branch="false"/>
+								<line number="692" hits="0" branch="false"/>
+								<line number="693" hits="0" branch="true" condition-coverage="0% (0/4)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+										<condition number="1" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="695" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="697" hits="0" branch="false"/>
+								<line number="699" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="700" hits="0" branch="false"/>
+								<line number="702" hits="0" branch="false"/>
+								<line number="703" hits="0" branch="false"/>
+								<line number="704" hits="0" branch="true" condition-coverage="0% (0/4)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+										<condition number="1" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="705" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="706" hits="0" branch="false"/>
+								<line number="708" hits="0" branch="false"/>
+								<line number="709" hits="0" branch="false"/>
+								<line number="711" hits="0" branch="false"/>
+								<line number="713" hits="0" branch="false"/>
+								<line number="715" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="716" hits="0" branch="true" condition-coverage="0% (0/4)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+										<condition number="1" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="718" hits="0" branch="false"/>
+								<line number="720" hits="0" branch="true" condition-coverage="0% (0/4)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+										<condition number="1" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="722" hits="0" branch="false"/>
+								<line number="724" hits="0" branch="true" condition-coverage="0% (0/10)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+										<condition number="1" type="jump" coverage="0%"/>
+										<condition number="2" type="jump" coverage="0%"/>
+										<condition number="3" type="jump" coverage="0%"/>
+										<condition number="4" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="729" hits="0" branch="false"/>
+								<line number="731" hits="0" branch="true" condition-coverage="0% (0/4)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+										<condition number="1" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="734" hits="0" branch="true" condition-coverage="0% (0/4)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+										<condition number="1" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="737" hits="0" branch="false"/>
+								<line number="742" hits="0" branch="true" condition-coverage="0% (0/4)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+										<condition number="1" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+							</lines>
+						</method>
+						<method name="maximum" signature="(III)I" line-rate="0.0" branch-rate="0.0">
+							<lines>
+								<line number="467" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="468" hits="0" branch="false"/>
+								<line number="470" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="471" hits="0" branch="false"/>
+								<line number="473" hits="0" branch="false"/>
+							</lines>
+						</method>
+						<method name="maximum" signature="(JJJ)J" line-rate="0.0" branch-rate="0.0">
+							<lines>
+								<line number="448" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="449" hits="0" branch="false"/>
+								<line number="451" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="452" hits="0" branch="false"/>
+								<line number="454" hits="0" branch="false"/>
+							</lines>
+						</method>
+						<method name="minimum" signature="(III)I" line-rate="0.0" branch-rate="0.0">
+							<lines>
+								<line number="429" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="430" hits="0" branch="false"/>
+								<line number="432" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="433" hits="0" branch="false"/>
+								<line number="435" hits="0" branch="false"/>
+							</lines>
+						</method>
+						<method name="minimum" signature="(JJJ)J" line-rate="0.0" branch-rate="0.0">
+							<lines>
+								<line number="410" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="411" hits="0" branch="false"/>
+								<line number="413" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="414" hits="0" branch="false"/>
+								<line number="416" hits="0" branch="false"/>
+							</lines>
+						</method>
+						<method name="stringToInt" signature="(Ljava/lang/String;)I" line-rate="0.0" branch-rate="1.0">
+							<lines>
+								<line number="65" hits="0" branch="false"/>
+							</lines>
+						</method>
+						<method name="stringToInt" signature="(Ljava/lang/String;I)I" line-rate="0.0" branch-rate="1.0">
+							<lines>
+								<line number="80" hits="0" branch="false"/>
+								<line number="81" hits="0" branch="false"/>
+								<line number="82" hits="0" branch="false"/>
+							</lines>
+						</method>
+					</methods>
+					<lines>
+						<line number="50" hits="0" branch="false"/>
+						<line number="51" hits="0" branch="false"/>
+						<line number="65" hits="0" branch="false"/>
+						<line number="80" hits="0" branch="false"/>
+						<line number="81" hits="0" branch="false"/>
+						<line number="82" hits="0" branch="false"/>
+						<line number="147" hits="36" branch="true" condition-coverage="50% (1/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+							</conditions>
+						</line>
+						<line number="148" hits="0" branch="false"/>
+						<line number="150" hits="36" branch="true" condition-coverage="50% (1/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+							</conditions>
+						</line>
+						<line number="151" hits="0" branch="false"/>
+						<line number="153" hits="36" branch="true" condition-coverage="50% (1/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+							</conditions>
+						</line>
+						<line number="158" hits="0" branch="false"/>
+						<line number="160" hits="36" branch="true" condition-coverage="50% (2/4)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+								<condition number="1" type="jump" coverage="50%"/>
+							</conditions>
+						</line>
+						<line number="161" hits="0" branch="false"/>
+						<line number="163" hits="36" branch="false"/>
+						<line number="167" hits="36" branch="false"/>
+						<line number="168" hits="36" branch="false"/>
+						<line number="170" hits="36" branch="true" condition-coverage="50% (1/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+							</conditions>
+						</line>
+						<line number="171" hits="36" branch="true" condition-coverage="50% (1/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+							</conditions>
+						</line>
+						<line number="172" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="173" hits="0" branch="false"/>
+						<line number="176" hits="0" branch="false"/>
+						<line number="178" hits="36" branch="false"/>
+						<line number="180" hits="36" branch="false"/>
+						<line number="182" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="183" hits="0" branch="false"/>
+						<line number="185" hits="0" branch="false"/>
+						<line number="187" hits="0" branch="false"/>
+						<line number="189" hits="36" branch="true" condition-coverage="50% (1/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+							</conditions>
+						</line>
+						<line number="190" hits="0" branch="true" condition-coverage="0% (0/4)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+								<condition number="1" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="191" hits="0" branch="false"/>
+						<line number="193" hits="0" branch="false"/>
+						<line number="196" hits="0" branch="false"/>
+						<line number="197" hits="0" branch="true" condition-coverage="0% (0/4)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+								<condition number="1" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="198" hits="0" branch="true" condition-coverage="0% (0/7)">
+							<conditions>
+								<condition number="0" type="switch" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="201" hits="0" branch="true" condition-coverage="0% (0/10)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+								<condition number="1" type="jump" coverage="0%"/>
+								<condition number="2" type="jump" coverage="0%"/>
+								<condition number="3" type="jump" coverage="0%"/>
+								<condition number="4" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="207" hits="0" branch="false"/>
+						<line number="208" hits="0" branch="false"/>
+						<line number="211" hits="0" branch="false"/>
+						<line number="213" hits="0" branch="false"/>
+						<line number="218" hits="0" branch="false"/>
+						<line number="219" hits="0" branch="true" condition-coverage="0% (0/6)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+								<condition number="1" type="jump" coverage="0%"/>
+								<condition number="2" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="225" hits="0" branch="false"/>
+						<line number="227" hits="0" branch="false"/>
+						<line number="228" hits="0" branch="false"/>
+						<line number="233" hits="0" branch="false"/>
+						<line number="234" hits="0" branch="true" condition-coverage="0% (0/6)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+								<condition number="1" type="jump" coverage="0%"/>
+								<condition number="2" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="236" hits="0" branch="false"/>
+						<line number="238" hits="0" branch="false"/>
+						<line number="239" hits="0" branch="false"/>
+						<line number="241" hits="0" branch="false"/>
+						<line number="242" hits="0" branch="false"/>
+						<line number="246" hits="0" branch="false"/>
+						<line number="252" hits="36" branch="true" condition-coverage="25% (1/4)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+								<condition number="1" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="253" hits="0" branch="false"/>
+						<line number="255" hits="36" branch="false"/>
+						<line number="257" hits="36" branch="true" condition-coverage="25% (1/4)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+								<condition number="1" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="260" hits="0" branch="false"/>
+						<line number="261" hits="0" branch="false"/>
+						<line number="264" hits="0" branch="false"/>
+						<line number="265" hits="0" branch="false"/>
+						<line number="267" hits="0" branch="false"/>
+						<line number="270" hits="36" branch="true" condition-coverage="25% (1/4)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+								<condition number="1" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="272" hits="36" branch="false"/>
+						<line number="273" hits="36" branch="true" condition-coverage="33% (2/6)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+								<condition number="1" type="jump" coverage="50%"/>
+								<condition number="2" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="275" hits="36" branch="false"/>
+						<line number="277" hits="0" branch="false"/>
+						<line number="278" hits="0" branch="false"/>
+						<line number="280" hits="0" branch="false"/>
+						<line number="281" hits="0" branch="true" condition-coverage="0% (0/6)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+								<condition number="1" type="jump" coverage="0%"/>
+								<condition number="2" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="283" hits="0" branch="false"/>
+						<line number="285" hits="0" branch="false"/>
+						<line number="286" hits="0" branch="false"/>
+						<line number="288" hits="0" branch="false"/>
+						<line number="303" hits="36" branch="true" condition-coverage="50% (1/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+							</conditions>
+						</line>
+						<line number="304" hits="0" branch="false"/>
+						<line number="306" hits="36" branch="true" condition-coverage="50% (1/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+							</conditions>
+						</line>
+						<line number="307" hits="36" branch="true" condition-coverage="50% (1/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+							</conditions>
+						</line>
+						<line number="308" hits="36" branch="false"/>
+						<line number="311" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="326" hits="36" branch="false"/>
+						<line number="339" hits="0" branch="false"/>
+						<line number="354" hits="0" branch="false"/>
+						<line number="367" hits="0" branch="false"/>
+						<line number="380" hits="0" branch="false"/>
+						<line number="381" hits="0" branch="false"/>
+						<line number="394" hits="0" branch="false"/>
+						<line number="395" hits="0" branch="false"/>
+						<line number="410" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="411" hits="0" branch="false"/>
+						<line number="413" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="414" hits="0" branch="false"/>
+						<line number="416" hits="0" branch="false"/>
+						<line number="429" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="430" hits="0" branch="false"/>
+						<line number="432" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="433" hits="0" branch="false"/>
+						<line number="435" hits="0" branch="false"/>
+						<line number="448" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="449" hits="0" branch="false"/>
+						<line number="451" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="452" hits="0" branch="false"/>
+						<line number="454" hits="0" branch="false"/>
+						<line number="467" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="468" hits="0" branch="false"/>
+						<line number="470" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="471" hits="0" branch="false"/>
+						<line number="473" hits="0" branch="false"/>
+						<line number="517" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="518" hits="0" branch="false"/>
+						<line number="520" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="521" hits="0" branch="false"/>
+						<line number="527" hits="0" branch="false"/>
+						<line number="528" hits="0" branch="false"/>
+						<line number="529" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="530" hits="0" branch="false"/>
+						<line number="538" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="539" hits="0" branch="false"/>
+						<line number="541" hits="0" branch="false"/>
+						<line number="583" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="584" hits="0" branch="false"/>
+						<line number="586" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="587" hits="0" branch="false"/>
+						<line number="593" hits="0" branch="false"/>
+						<line number="594" hits="0" branch="false"/>
+						<line number="595" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="596" hits="0" branch="false"/>
+						<line number="604" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="605" hits="0" branch="false"/>
+						<line number="607" hits="0" branch="false"/>
+						<line number="624" hits="0" branch="true" condition-coverage="0% (0/4)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+								<condition number="1" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="625" hits="0" branch="false"/>
+						<line number="627" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="628" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="629" hits="0" branch="false"/>
+						<line number="632" hits="0" branch="false"/>
+						<line number="649" hits="0" branch="true" condition-coverage="0% (0/4)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+								<condition number="1" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="650" hits="0" branch="false"/>
+						<line number="652" hits="0" branch="false"/>
+						<line number="653" hits="0" branch="false"/>
+						<line number="654" hits="0" branch="false"/>
+						<line number="655" hits="0" branch="false"/>
+						<line number="656" hits="0" branch="false"/>
+						<line number="657" hits="0" branch="false"/>
+						<line number="659" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="660" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="661" hits="0" branch="true" condition-coverage="0% (0/4)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+								<condition number="1" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="662" hits="0" branch="false"/>
+						<line number="663" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="664" hits="0" branch="false"/>
+						<line number="667" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="668" hits="0" branch="true" condition-coverage="0% (0/12)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+								<condition number="1" type="jump" coverage="0%"/>
+								<condition number="2" type="jump" coverage="0%"/>
+								<condition number="3" type="jump" coverage="0%"/>
+								<condition number="4" type="jump" coverage="0%"/>
+								<condition number="5" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="671" hits="0" branch="false"/>
+						<line number="674" hits="0" branch="false"/>
+						<line number="677" hits="0" branch="false"/>
+						<line number="679" hits="0" branch="false"/>
+						<line number="683" hits="0" branch="true" condition-coverage="0% (0/8)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+								<condition number="1" type="jump" coverage="0%"/>
+								<condition number="2" type="jump" coverage="0%"/>
+								<condition number="3" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="684" hits="0" branch="true" condition-coverage="0% (0/4)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+								<condition number="1" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="685" hits="0" branch="false"/>
+						<line number="686" hits="0" branch="false"/>
+						<line number="687" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="688" hits="0" branch="true" condition-coverage="0% (0/4)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+								<condition number="1" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="690" hits="0" branch="false"/>
+						<line number="692" hits="0" branch="false"/>
+						<line number="693" hits="0" branch="true" condition-coverage="0% (0/4)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+								<condition number="1" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="695" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="697" hits="0" branch="false"/>
+						<line number="699" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="700" hits="0" branch="false"/>
+						<line number="702" hits="0" branch="false"/>
+						<line number="703" hits="0" branch="false"/>
+						<line number="704" hits="0" branch="true" condition-coverage="0% (0/4)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+								<condition number="1" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="705" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="706" hits="0" branch="false"/>
+						<line number="708" hits="0" branch="false"/>
+						<line number="709" hits="0" branch="false"/>
+						<line number="711" hits="0" branch="false"/>
+						<line number="713" hits="0" branch="false"/>
+						<line number="715" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="716" hits="0" branch="true" condition-coverage="0% (0/4)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+								<condition number="1" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="718" hits="0" branch="false"/>
+						<line number="720" hits="0" branch="true" condition-coverage="0% (0/4)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+								<condition number="1" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="722" hits="0" branch="false"/>
+						<line number="724" hits="0" branch="true" condition-coverage="0% (0/10)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+								<condition number="1" type="jump" coverage="0%"/>
+								<condition number="2" type="jump" coverage="0%"/>
+								<condition number="3" type="jump" coverage="0%"/>
+								<condition number="4" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="729" hits="0" branch="false"/>
+						<line number="731" hits="0" branch="true" condition-coverage="0% (0/4)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+								<condition number="1" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="734" hits="0" branch="true" condition-coverage="0% (0/4)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+								<condition number="1" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="737" hits="0" branch="false"/>
+						<line number="742" hits="0" branch="true" condition-coverage="0% (0/4)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+								<condition number="1" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+					</lines>
+				</class>
+				<class name="org.apache.commons.cli.Option" filename="org/apache/commons/cli/Option.java" line-rate="0.7980769230769231" branch-rate="0.6984126984126984" complexity="1.6857142857142857">
+					<methods>
+						<method name="&lt;init&gt;" signature="(Ljava/lang/String;Ljava/lang/String;)V" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="152" hits="10980" branch="false"/>
+								<line number="153" hits="10926" branch="false"/>
+							</lines>
+						</method>
+						<method name="&lt;init&gt;" signature="(Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;)V" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="128" hits="15048" branch="false"/>
+								<line number="134" hits="15048" branch="false"/>
+								<line number="180" hits="15048" branch="false"/>
+								<line number="182" hits="15048" branch="false"/>
+								<line number="184" hits="14994" branch="false"/>
+								<line number="185" hits="14994" branch="false"/>
+								<line number="188" hits="14994" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="189" hits="1206" branch="false"/>
+								<line number="192" hits="14994" branch="false"/>
+								<line number="193" hits="14994" branch="false"/>
+								<line number="194" hits="14994" branch="false"/>
+							</lines>
+						</method>
+						<method name="&lt;init&gt;" signature="(Ljava/lang/String;ZLjava/lang/String;)V" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="166" hits="36" branch="false"/>
+								<line number="167" hits="36" branch="false"/>
+							</lines>
+						</method>
+						<method name="addValue" signature="(Ljava/lang/String;)Z" line-rate="0.75" branch-rate="0.7333333333333333">
+							<lines>
+								<line number="499" hits="3006" branch="true" condition-coverage="67% (2/3)">
+									<conditions>
+										<condition number="0" type="switch" coverage="67%"/>
+									</conditions>
+								</line>
+								<line number="501" hits="0" branch="false"/>
+								<line number="503" hits="1026" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="504" hits="702" branch="false"/>
+								<line number="505" hits="1422" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="506" hits="720" branch="false"/>
+								<line number="507" hits="720" branch="false"/>
+								<line number="510" hits="1026" branch="false"/>
+								<line number="511" hits="1026" branch="false"/>
+								<line number="513" hits="1980" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="514" hits="18" branch="false"/>
+								<line number="515" hits="18" branch="true" condition-coverage="50% (1/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+									</conditions>
+								</line>
+								<line number="516" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="517" hits="0" branch="false"/>
+								<line number="519" hits="0" branch="false"/>
+								<line number="520" hits="0" branch="false"/>
+								<line number="523" hits="1980" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="524" hits="252" branch="false"/>
+								<line number="526" hits="1728" branch="false"/>
+								<line number="527" hits="1728" branch="false"/>
+							</lines>
+						</method>
+						<method name="clone" signature="()Ljava/lang/Object;" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="596" hits="8172" branch="false"/>
+								<line number="597" hits="8172" branch="false"/>
+								<line number="598" hits="8172" branch="false"/>
+								<line number="599" hits="8172" branch="false"/>
+								<line number="600" hits="8172" branch="false"/>
+								<line number="601" hits="8172" branch="false"/>
+								<line number="602" hits="8172" branch="false"/>
+								<line number="603" hits="8172" branch="false"/>
+							</lines>
+						</method>
+						<method name="getArgName" signature="()Ljava/lang/String;" line-rate="0.0" branch-rate="1.0">
+							<lines>
+								<line number="402" hits="0" branch="false"/>
+							</lines>
+						</method>
+						<method name="getArgs" signature="()I" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="458" hits="8190" branch="false"/>
+							</lines>
+						</method>
+						<method name="getDescription" signature="()Ljava/lang/String;" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="366" hits="8388" branch="false"/>
+							</lines>
+						</method>
+						<method name="getId" signature="()I" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="268" hits="36" branch="false"/>
+							</lines>
+						</method>
+						<method name="getLongOpt" signature="()Ljava/lang/String;" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="311" hits="12906" branch="false"/>
+							</lines>
+						</method>
+						<method name="getOpt" signature="()Ljava/lang/String;" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="284" hits="25758" branch="false"/>
+							</lines>
+						</method>
+						<method name="getType" signature="()Ljava/lang/Object;" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="293" hits="8442" branch="false"/>
+							</lines>
+						</method>
+						<method name="getValue" signature="()Ljava/lang/String;" line-rate="0.0" branch-rate="0.0">
+							<lines>
+								<line number="538" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+							</lines>
+						</method>
+						<method name="getValue" signature="(I)Ljava/lang/String;" line-rate="1.0" branch-rate="0.5">
+							<lines>
+								<line number="552" hits="90" branch="true" condition-coverage="50% (1/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+									</conditions>
+								</line>
+							</lines>
+						</method>
+						<method name="getValue" signature="(Ljava/lang/String;)Ljava/lang/String;" line-rate="0.0" branch-rate="0.0">
+							<lines>
+								<line number="565" hits="0" branch="false"/>
+								<line number="566" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+							</lines>
+						</method>
+						<method name="getValueSeparator" signature="()C" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="449" hits="12618" branch="false"/>
+							</lines>
+						</method>
+						<method name="getValues" signature="()[Ljava/lang/String;" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="576" hits="2556" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+							</lines>
+						</method>
+						<method name="getValuesList" signature="()Ljava/util/List;" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="587" hits="1656" branch="false"/>
+							</lines>
+						</method>
+						<method name="hasArg" signature="()Z" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="357" hits="5904" branch="true" condition-coverage="100% (4/4)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+										<condition number="1" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+							</lines>
+						</method>
+						<method name="hasArgName" signature="()Z" line-rate="1.0" branch-rate="0.25">
+							<lines>
+								<line number="412" hits="18" branch="true" condition-coverage="25% (1/4)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+										<condition number="1" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+							</lines>
+						</method>
+						<method name="hasArgs" signature="()Z" line-rate="1.0" branch-rate="0.75">
+							<lines>
+								<line number="421" hits="54" branch="true" condition-coverage="75% (3/4)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+										<condition number="1" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+							</lines>
+						</method>
+						<method name="hasLongOpt" signature="()Z" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="348" hits="6678" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+							</lines>
+						</method>
+						<method name="hasOptionalArg" signature="()Z" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="339" hits="8298" branch="false"/>
+							</lines>
+						</method>
+						<method name="isRequired" signature="()Z" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="375" hits="19260" branch="false"/>
+							</lines>
+						</method>
+						<method name="isValidChar" signature="(C)Z" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="258" hits="18270" branch="false"/>
+							</lines>
+						</method>
+						<method name="isValidOpt" signature="(C)Z" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="247" hits="14490" branch="true" condition-coverage="100% (8/8)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+										<condition number="1" type="jump" coverage="100%"/>
+										<condition number="2" type="jump" coverage="100%"/>
+										<condition number="3" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+							</lines>
+						</method>
+						<method name="setArgName" signature="(Ljava/lang/String;)V" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="393" hits="2754" branch="false"/>
+								<line number="394" hits="2754" branch="false"/>
+							</lines>
+						</method>
+						<method name="setArgs" signature="(I)V" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="430" hits="10926" branch="false"/>
+								<line number="431" hits="10926" branch="false"/>
+							</lines>
+						</method>
+						<method name="setLongOpt" signature="(Ljava/lang/String;)V" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="320" hits="10926" branch="false"/>
+								<line number="321" hits="10926" branch="false"/>
+							</lines>
+						</method>
+						<method name="setOptionalArg" signature="(Z)V" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="330" hits="10926" branch="false"/>
+								<line number="331" hits="10926" branch="false"/>
+							</lines>
+						</method>
+						<method name="setRequired" signature="(Z)V" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="384" hits="11664" branch="false"/>
+								<line number="385" hits="11664" branch="false"/>
+							</lines>
+						</method>
+						<method name="setType" signature="(Ljava/lang/Object;)V" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="302" hits="10926" branch="false"/>
+								<line number="303" hits="10926" branch="false"/>
+							</lines>
+						</method>
+						<method name="setValueSeparator" signature="(C)V" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="440" hits="10926" branch="false"/>
+								<line number="441" hits="10926" branch="false"/>
+							</lines>
+						</method>
+						<method name="toString" signature="()Ljava/lang/String;" line-rate="0.0" branch-rate="0.0">
+							<lines>
+								<line number="467" hits="0" branch="false"/>
+								<line number="469" hits="0" branch="false"/>
+								<line number="471" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="472" hits="0" branch="false"/>
+								<line number="475" hits="0" branch="false"/>
+								<line number="477" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="478" hits="0" branch="false"/>
+								<line number="481" hits="0" branch="false"/>
+								<line number="483" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="484" hits="0" branch="false"/>
+								<line number="487" hits="0" branch="false"/>
+								<line number="488" hits="0" branch="false"/>
+							</lines>
+						</method>
+						<method name="validateOption" signature="(Ljava/lang/String;)V" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="213" hits="15048" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="214" hits="18" branch="false"/>
+								<line number="217" hits="15030" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="218" hits="14490" branch="false"/>
+								<line number="219" hits="14490" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="220" hits="18" branch="false"/>
+								<line number="223" hits="14472" branch="false"/>
+								<line number="224" hits="14472" branch="false"/>
+								<line number="227" hits="540" branch="false"/>
+								<line number="228" hits="4302" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="229" hits="3780" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="230" hits="18" branch="false"/>
+								<line number="236" hits="14994" branch="false"/>
+							</lines>
+						</method>
+					</methods>
+					<lines>
+						<line number="128" hits="15048" branch="false"/>
+						<line number="134" hits="15048" branch="false"/>
+						<line number="152" hits="10980" branch="false"/>
+						<line number="153" hits="10926" branch="false"/>
+						<line number="166" hits="36" branch="false"/>
+						<line number="167" hits="36" branch="false"/>
+						<line number="180" hits="15048" branch="false"/>
+						<line number="182" hits="15048" branch="false"/>
+						<line number="184" hits="14994" branch="false"/>
+						<line number="185" hits="14994" branch="false"/>
+						<line number="188" hits="14994" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="189" hits="1206" branch="false"/>
+						<line number="192" hits="14994" branch="false"/>
+						<line number="193" hits="14994" branch="false"/>
+						<line number="194" hits="14994" branch="false"/>
+						<line number="213" hits="15048" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="214" hits="18" branch="false"/>
+						<line number="217" hits="15030" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="218" hits="14490" branch="false"/>
+						<line number="219" hits="14490" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="220" hits="18" branch="false"/>
+						<line number="223" hits="14472" branch="false"/>
+						<line number="224" hits="14472" branch="false"/>
+						<line number="227" hits="540" branch="false"/>
+						<line number="228" hits="4302" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="229" hits="3780" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="230" hits="18" branch="false"/>
+						<line number="236" hits="14994" branch="false"/>
+						<line number="247" hits="14490" branch="true" condition-coverage="100% (8/8)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+								<condition number="1" type="jump" coverage="100%"/>
+								<condition number="2" type="jump" coverage="100%"/>
+								<condition number="3" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="258" hits="18270" branch="false"/>
+						<line number="268" hits="36" branch="false"/>
+						<line number="284" hits="25758" branch="false"/>
+						<line number="293" hits="8442" branch="false"/>
+						<line number="302" hits="10926" branch="false"/>
+						<line number="303" hits="10926" branch="false"/>
+						<line number="311" hits="12906" branch="false"/>
+						<line number="320" hits="10926" branch="false"/>
+						<line number="321" hits="10926" branch="false"/>
+						<line number="330" hits="10926" branch="false"/>
+						<line number="331" hits="10926" branch="false"/>
+						<line number="339" hits="8298" branch="false"/>
+						<line number="348" hits="6678" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="357" hits="5904" branch="true" condition-coverage="100% (4/4)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+								<condition number="1" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="366" hits="8388" branch="false"/>
+						<line number="375" hits="19260" branch="false"/>
+						<line number="384" hits="11664" branch="false"/>
+						<line number="385" hits="11664" branch="false"/>
+						<line number="393" hits="2754" branch="false"/>
+						<line number="394" hits="2754" branch="false"/>
+						<line number="402" hits="0" branch="false"/>
+						<line number="412" hits="18" branch="true" condition-coverage="25% (1/4)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+								<condition number="1" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="421" hits="54" branch="true" condition-coverage="75% (3/4)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+								<condition number="1" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="430" hits="10926" branch="false"/>
+						<line number="431" hits="10926" branch="false"/>
+						<line number="440" hits="10926" branch="false"/>
+						<line number="441" hits="10926" branch="false"/>
+						<line number="449" hits="12618" branch="false"/>
+						<line number="458" hits="8190" branch="false"/>
+						<line number="467" hits="0" branch="false"/>
+						<line number="469" hits="0" branch="false"/>
+						<line number="471" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="472" hits="0" branch="false"/>
+						<line number="475" hits="0" branch="false"/>
+						<line number="477" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="478" hits="0" branch="false"/>
+						<line number="481" hits="0" branch="false"/>
+						<line number="483" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="484" hits="0" branch="false"/>
+						<line number="487" hits="0" branch="false"/>
+						<line number="488" hits="0" branch="false"/>
+						<line number="499" hits="3006" branch="true" condition-coverage="67% (2/3)">
+							<conditions>
+								<condition number="0" type="switch" coverage="67%"/>
+							</conditions>
+						</line>
+						<line number="501" hits="0" branch="false"/>
+						<line number="503" hits="1026" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="504" hits="702" branch="false"/>
+						<line number="505" hits="1422" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="506" hits="720" branch="false"/>
+						<line number="507" hits="720" branch="false"/>
+						<line number="510" hits="1026" branch="false"/>
+						<line number="511" hits="1026" branch="false"/>
+						<line number="513" hits="1980" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="514" hits="18" branch="false"/>
+						<line number="515" hits="18" branch="true" condition-coverage="50% (1/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+							</conditions>
+						</line>
+						<line number="516" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="517" hits="0" branch="false"/>
+						<line number="519" hits="0" branch="false"/>
+						<line number="520" hits="0" branch="false"/>
+						<line number="523" hits="1980" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="524" hits="252" branch="false"/>
+						<line number="526" hits="1728" branch="false"/>
+						<line number="527" hits="1728" branch="false"/>
+						<line number="538" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="552" hits="90" branch="true" condition-coverage="50% (1/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+							</conditions>
+						</line>
+						<line number="565" hits="0" branch="false"/>
+						<line number="566" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="576" hits="2556" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="587" hits="1656" branch="false"/>
+						<line number="596" hits="8172" branch="false"/>
+						<line number="597" hits="8172" branch="false"/>
+						<line number="598" hits="8172" branch="false"/>
+						<line number="599" hits="8172" branch="false"/>
+						<line number="600" hits="8172" branch="false"/>
+						<line number="601" hits="8172" branch="false"/>
+						<line number="602" hits="8172" branch="false"/>
+						<line number="603" hits="8172" branch="false"/>
+					</lines>
+				</class>
+				<class name="org.apache.commons.cli.OptionBuilder" filename="org/apache/commons/cli/OptionBuilder.java" line-rate="0.95" branch-rate="0.75" complexity="1.1">
+					<methods>
+						<method name="&lt;clinit&gt;" signature="()V" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="90" hits="126" branch="false"/>
+								<line number="102" hits="126" branch="false"/>
+							</lines>
+						</method>
+						<method name="&lt;init&gt;" signature="()V" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="107" hits="126" branch="false"/>
+								<line number="108" hits="126" branch="false"/>
+							</lines>
+						</method>
+						<method name="create" signature="()Lorg/apache/commons/cli/Option;" line-rate="0.6666666666666666" branch-rate="0.5">
+							<lines>
+								<line number="350" hits="684" branch="true" condition-coverage="50% (1/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+									</conditions>
+								</line>
+								<line number="351" hits="0" branch="false"/>
+								<line number="354" hits="684" branch="false"/>
+							</lines>
+						</method>
+						<method name="create" signature="(C)Lorg/apache/commons/cli/Option;" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="338" hits="2052" branch="false"/>
+							</lines>
+						</method>
+						<method name="create" signature="(Ljava/lang/String;)Lorg/apache/commons/cli/Option;" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="370" hits="2808" branch="false"/>
+								<line number="373" hits="2754" branch="false"/>
+								<line number="374" hits="2754" branch="false"/>
+								<line number="375" hits="2754" branch="false"/>
+								<line number="376" hits="2754" branch="false"/>
+								<line number="377" hits="2754" branch="false"/>
+								<line number="378" hits="2754" branch="false"/>
+								<line number="379" hits="2754" branch="false"/>
+								<line number="381" hits="2754" branch="false"/>
+								<line number="384" hits="2754" branch="false"/>
+							</lines>
+						</method>
+						<method name="hasArg" signature="()Lorg/apache/commons/cli/OptionBuilder;" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="144" hits="216" branch="false"/>
+								<line number="145" hits="216" branch="false"/>
+							</lines>
+						</method>
+						<method name="hasArg" signature="(Z)Lorg/apache/commons/cli/OptionBuilder;" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="157" hits="144" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="158" hits="144" branch="false"/>
+							</lines>
+						</method>
+						<method name="hasArgs" signature="()Lorg/apache/commons/cli/OptionBuilder;" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="247" hits="594" branch="false"/>
+								<line number="248" hits="594" branch="false"/>
+							</lines>
+						</method>
+						<method name="hasArgs" signature="(I)Lorg/apache/commons/cli/OptionBuilder;" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="259" hits="270" branch="false"/>
+								<line number="260" hits="270" branch="false"/>
+							</lines>
+						</method>
+						<method name="hasOptionalArg" signature="()Lorg/apache/commons/cli/OptionBuilder;" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="269" hits="468" branch="false"/>
+								<line number="270" hits="468" branch="false"/>
+								<line number="271" hits="468" branch="false"/>
+							</lines>
+						</method>
+						<method name="hasOptionalArgs" signature="()Lorg/apache/commons/cli/OptionBuilder;" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="281" hits="432" branch="false"/>
+								<line number="282" hits="432" branch="false"/>
+								<line number="283" hits="432" branch="false"/>
+							</lines>
+						</method>
+						<method name="hasOptionalArgs" signature="(I)Lorg/apache/commons/cli/OptionBuilder;" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="296" hits="432" branch="false"/>
+								<line number="297" hits="432" branch="false"/>
+								<line number="298" hits="432" branch="false"/>
+							</lines>
+						</method>
+						<method name="isRequired" signature="()Lorg/apache/commons/cli/OptionBuilder;" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="180" hits="90" branch="false"/>
+								<line number="181" hits="90" branch="false"/>
+							</lines>
+						</method>
+						<method name="isRequired" signature="(Z)Lorg/apache/commons/cli/OptionBuilder;" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="237" hits="144" branch="false"/>
+								<line number="238" hits="144" branch="false"/>
+							</lines>
+						</method>
+						<method name="reset" signature="()V" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="114" hits="2754" branch="false"/>
+								<line number="115" hits="2754" branch="false"/>
+								<line number="116" hits="2754" branch="false"/>
+								<line number="117" hits="2754" branch="false"/>
+								<line number="118" hits="2754" branch="false"/>
+								<line number="119" hits="2754" branch="false"/>
+								<line number="122" hits="2754" branch="false"/>
+								<line number="123" hits="2754" branch="false"/>
+								<line number="124" hits="2754" branch="false"/>
+							</lines>
+						</method>
+						<method name="withArgName" signature="(Ljava/lang/String;)Lorg/apache/commons/cli/OptionBuilder;" line-rate="0.0" branch-rate="1.0">
+							<lines>
+								<line number="170" hits="0" branch="false"/>
+								<line number="171" hits="0" branch="false"/>
+							</lines>
+						</method>
+						<method name="withDescription" signature="(Ljava/lang/String;)Lorg/apache/commons/cli/OptionBuilder;" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="322" hits="1188" branch="false"/>
+								<line number="323" hits="1188" branch="false"/>
+							</lines>
+						</method>
+						<method name="withLongOpt" signature="(Ljava/lang/String;)Lorg/apache/commons/cli/OptionBuilder;" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="134" hits="1710" branch="false"/>
+								<line number="135" hits="1710" branch="false"/>
+							</lines>
+						</method>
+						<method name="withType" signature="(Ljava/lang/Object;)Lorg/apache/commons/cli/OptionBuilder;" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="310" hits="180" branch="false"/>
+								<line number="311" hits="180" branch="false"/>
+							</lines>
+						</method>
+						<method name="withValueSeparator" signature="()Lorg/apache/commons/cli/OptionBuilder;" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="224" hits="144" branch="false"/>
+								<line number="225" hits="144" branch="false"/>
+							</lines>
+						</method>
+						<method name="withValueSeparator" signature="(C)Lorg/apache/commons/cli/OptionBuilder;" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="203" hits="306" branch="false"/>
+								<line number="204" hits="306" branch="false"/>
+							</lines>
+						</method>
+					</methods>
+					<lines>
+						<line number="90" hits="126" branch="false"/>
+						<line number="102" hits="126" branch="false"/>
+						<line number="107" hits="126" branch="false"/>
+						<line number="108" hits="126" branch="false"/>
+						<line number="114" hits="2754" branch="false"/>
+						<line number="115" hits="2754" branch="false"/>
+						<line number="116" hits="2754" branch="false"/>
+						<line number="117" hits="2754" branch="false"/>
+						<line number="118" hits="2754" branch="false"/>
+						<line number="119" hits="2754" branch="false"/>
+						<line number="122" hits="2754" branch="false"/>
+						<line number="123" hits="2754" branch="false"/>
+						<line number="124" hits="2754" branch="false"/>
+						<line number="134" hits="1710" branch="false"/>
+						<line number="135" hits="1710" branch="false"/>
+						<line number="144" hits="216" branch="false"/>
+						<line number="145" hits="216" branch="false"/>
+						<line number="157" hits="144" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="158" hits="144" branch="false"/>
+						<line number="170" hits="0" branch="false"/>
+						<line number="171" hits="0" branch="false"/>
+						<line number="180" hits="90" branch="false"/>
+						<line number="181" hits="90" branch="false"/>
+						<line number="203" hits="306" branch="false"/>
+						<line number="204" hits="306" branch="false"/>
+						<line number="224" hits="144" branch="false"/>
+						<line number="225" hits="144" branch="false"/>
+						<line number="237" hits="144" branch="false"/>
+						<line number="238" hits="144" branch="false"/>
+						<line number="247" hits="594" branch="false"/>
+						<line number="248" hits="594" branch="false"/>
+						<line number="259" hits="270" branch="false"/>
+						<line number="260" hits="270" branch="false"/>
+						<line number="269" hits="468" branch="false"/>
+						<line number="270" hits="468" branch="false"/>
+						<line number="271" hits="468" branch="false"/>
+						<line number="281" hits="432" branch="false"/>
+						<line number="282" hits="432" branch="false"/>
+						<line number="283" hits="432" branch="false"/>
+						<line number="296" hits="432" branch="false"/>
+						<line number="297" hits="432" branch="false"/>
+						<line number="298" hits="432" branch="false"/>
+						<line number="310" hits="180" branch="false"/>
+						<line number="311" hits="180" branch="false"/>
+						<line number="322" hits="1188" branch="false"/>
+						<line number="323" hits="1188" branch="false"/>
+						<line number="338" hits="2052" branch="false"/>
+						<line number="350" hits="684" branch="true" condition-coverage="50% (1/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+							</conditions>
+						</line>
+						<line number="351" hits="0" branch="false"/>
+						<line number="354" hits="684" branch="false"/>
+						<line number="370" hits="2808" branch="false"/>
+						<line number="373" hits="2754" branch="false"/>
+						<line number="374" hits="2754" branch="false"/>
+						<line number="375" hits="2754" branch="false"/>
+						<line number="376" hits="2754" branch="false"/>
+						<line number="377" hits="2754" branch="false"/>
+						<line number="378" hits="2754" branch="false"/>
+						<line number="379" hits="2754" branch="false"/>
+						<line number="381" hits="2754" branch="false"/>
+						<line number="384" hits="2754" branch="false"/>
+					</lines>
+				</class>
+				<class name="org.apache.commons.cli.OptionGroup" filename="org/apache/commons/cli/OptionGroup.java" line-rate="0.8387096774193549" branch-rate="0.8" complexity="1.5555555555555556">
+					<methods>
+						<method name="&lt;init&gt;" signature="()V" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="76" hits="360" branch="false"/>
+								<line number="78" hits="360" branch="false"/>
+							</lines>
+						</method>
+						<method name="addOption" signature="(Lorg/apache/commons/cli/Option;)Lorg/apache/commons/cli/OptionGroup;" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="97" hits="720" branch="false"/>
+								<line number="98" hits="720" branch="false"/>
+							</lines>
+						</method>
+						<method name="getNames" signature="()Ljava/util/Collection;" line-rate="0.0" branch-rate="1.0">
+							<lines>
+								<line number="127" hits="0" branch="false"/>
+							</lines>
+						</method>
+						<method name="getOption" signature="(Ljava/lang/String;)Lorg/apache/commons/cli/Option;" line-rate="0.0" branch-rate="0.0">
+							<lines>
+								<line number="113" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="114" hits="0" branch="false"/>
+								<line number="116" hits="0" branch="false"/>
+							</lines>
+						</method>
+						<method name="getOptions" signature="()Ljava/util/Collection;" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="137" hits="396" branch="false"/>
+							</lines>
+						</method>
+						<method name="getSelected" signature="()Ljava/lang/String;" line-rate="0.0" branch-rate="1.0">
+							<lines>
+								<line number="168" hits="0" branch="false"/>
+							</lines>
+						</method>
+						<method name="isRequired" signature="()Z" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="188" hits="594" branch="false"/>
+							</lines>
+						</method>
+						<method name="setRequired" signature="(Z)V" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="177" hits="18" branch="false"/>
+								<line number="178" hits="18" branch="false"/>
+							</lines>
+						</method>
+						<method name="setSelected" signature="(Lorg/apache/commons/cli/Option;)V" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="153" hits="234" branch="true" condition-coverage="100% (4/4)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+										<condition number="1" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="154" hits="198" branch="false"/>
+								<line number="156" hits="36" branch="false"/>
+								<line number="160" hits="198" branch="false"/>
+							</lines>
+						</method>
+						<method name="toString" signature="()Ljava/lang/String;" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="197" hits="36" branch="false"/>
+								<line number="199" hits="36" branch="false"/>
+								<line number="201" hits="36" branch="false"/>
+								<line number="202" hits="108" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="203" hits="72" branch="false"/>
+								<line number="205" hits="72" branch="false"/>
+								<line number="206" hits="72" branch="false"/>
+								<line number="207" hits="72" branch="false"/>
+								<line number="208" hits="72" branch="false"/>
+								<line number="210" hits="72" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="211" hits="36" branch="false"/>
+								<line number="213" hits="72" branch="false"/>
+								<line number="214" hits="36" branch="false"/>
+								<line number="216" hits="36" branch="false"/>
+							</lines>
+						</method>
+					</methods>
+					<lines>
+						<line number="76" hits="360" branch="false"/>
+						<line number="78" hits="360" branch="false"/>
+						<line number="97" hits="720" branch="false"/>
+						<line number="98" hits="720" branch="false"/>
+						<line number="113" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="114" hits="0" branch="false"/>
+						<line number="116" hits="0" branch="false"/>
+						<line number="127" hits="0" branch="false"/>
+						<line number="137" hits="396" branch="false"/>
+						<line number="153" hits="234" branch="true" condition-coverage="100% (4/4)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+								<condition number="1" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="154" hits="198" branch="false"/>
+						<line number="156" hits="36" branch="false"/>
+						<line number="160" hits="198" branch="false"/>
+						<line number="168" hits="0" branch="false"/>
+						<line number="177" hits="18" branch="false"/>
+						<line number="178" hits="18" branch="false"/>
+						<line number="188" hits="594" branch="false"/>
+						<line number="197" hits="36" branch="false"/>
+						<line number="199" hits="36" branch="false"/>
+						<line number="201" hits="36" branch="false"/>
+						<line number="202" hits="108" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="203" hits="72" branch="false"/>
+						<line number="205" hits="72" branch="false"/>
+						<line number="206" hits="72" branch="false"/>
+						<line number="207" hits="72" branch="false"/>
+						<line number="208" hits="72" branch="false"/>
+						<line number="210" hits="72" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="211" hits="36" branch="false"/>
+						<line number="213" hits="72" branch="false"/>
+						<line number="214" hits="36" branch="false"/>
+						<line number="216" hits="36" branch="false"/>
+					</lines>
+				</class>
+				<class name="org.apache.commons.cli.Options" filename="org/apache/commons/cli/Options.java" line-rate="0.7368421052631579" branch-rate="0.8181818181818182" complexity="2.0">
+					<methods>
+						<method name="&lt;init&gt;" signature="()V" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="90" hits="1224" branch="false"/>
+								<line number="93" hits="1224" branch="false"/>
+								<line number="96" hits="1224" branch="false"/>
+								<line number="99" hits="1224" branch="false"/>
+								<line number="106" hits="1224" branch="false"/>
+								<line number="107" hits="1224" branch="false"/>
+							</lines>
+						</method>
+						<method name="addOption" signature="(Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;)Lorg/apache/commons/cli/Options;" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="159" hits="3312" branch="false"/>
+								<line number="160" hits="3312" branch="false"/>
+							</lines>
+						</method>
+						<method name="addOption" signature="(Ljava/lang/String;ZLjava/lang/String;)Lorg/apache/commons/cli/Options;" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="145" hits="1116" branch="false"/>
+								<line number="146" hits="1116" branch="false"/>
+							</lines>
+						</method>
+						<method name="addOption" signature="(Lorg/apache/commons/cli/Option;)Lorg/apache/commons/cli/Options;" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="170" hits="6660" branch="false"/>
+								<line number="173" hits="6660" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="174" hits="4572" branch="false"/>
+								<line number="178" hits="6660" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="179" hits="72" branch="false"/>
+								<line number="182" hits="6660" branch="false"/>
+								<line number="184" hits="6660" branch="false"/>
+							</lines>
+						</method>
+						<method name="addOptionGroup" signature="(Lorg/apache/commons/cli/OptionGroup;)Lorg/apache/commons/cli/Options;" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="116" hits="360" branch="false"/>
+								<line number="118" hits="360" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="119" hits="18" branch="false"/>
+								<line number="122" hits="1080" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="123" hits="720" branch="false"/>
+								<line number="127" hits="720" branch="false"/>
+								<line number="128" hits="720" branch="false"/>
+								<line number="130" hits="720" branch="false"/>
+								<line number="131" hits="720" branch="false"/>
+								<line number="133" hits="360" branch="false"/>
+							</lines>
+						</method>
+						<method name="getOption" signature="(Ljava/lang/String;)Lorg/apache/commons/cli/Option;" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="233" hits="8496" branch="false"/>
+								<line number="236" hits="8496" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="237" hits="756" branch="false"/>
+								<line number="240" hits="7740" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="241" hits="1350" branch="false"/>
+								<line number="245" hits="6390" branch="false"/>
+								<line number="248" hits="8496" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+							</lines>
+						</method>
+						<method name="getOptionGroup" signature="(Lorg/apache/commons/cli/Option;)Lorg/apache/commons/cli/OptionGroup;" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="283" hits="4608" branch="false"/>
+							</lines>
+						</method>
+						<method name="getOptions" signature="()Ljava/util/Collection;" line-rate="0.0" branch-rate="0.0">
+							<lines>
+								<line number="192" hits="0" branch="false"/>
+								<line number="196" hits="0" branch="false"/>
+								<line number="197" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="199" hits="0" branch="false"/>
+								<line number="200" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="202" hits="0" branch="false"/>
+								<line number="204" hits="0" branch="false"/>
+								<line number="205" hits="0" branch="false"/>
+							</lines>
+						</method>
+						<method name="getRequiredOptions" signature="()Ljava/util/List;" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="223" hits="1386" branch="false"/>
+							</lines>
+						</method>
+						<method name="hasOption" signature="(Ljava/lang/String;)Z" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="262" hits="12186" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="263" hits="774" branch="false"/>
+								<line number="266" hits="11412" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="267" hits="1476" branch="false"/>
+								<line number="271" hits="9936" branch="false"/>
+							</lines>
+						</method>
+						<method name="helpOptions" signature="()Ljava/util/List;" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="214" hits="18" branch="false"/>
+							</lines>
+						</method>
+						<method name="toString" signature="()Ljava/lang/String;" line-rate="0.0" branch-rate="1.0">
+							<lines>
+								<line number="291" hits="0" branch="false"/>
+								<line number="293" hits="0" branch="false"/>
+								<line number="294" hits="0" branch="false"/>
+								<line number="295" hits="0" branch="false"/>
+								<line number="296" hits="0" branch="false"/>
+								<line number="297" hits="0" branch="false"/>
+								<line number="299" hits="0" branch="false"/>
+							</lines>
+						</method>
+					</methods>
+					<lines>
+						<line number="90" hits="1224" branch="false"/>
+						<line number="93" hits="1224" branch="false"/>
+						<line number="96" hits="1224" branch="false"/>
+						<line number="99" hits="1224" branch="false"/>
+						<line number="106" hits="1224" branch="false"/>
+						<line number="107" hits="1224" branch="false"/>
+						<line number="116" hits="360" branch="false"/>
+						<line number="118" hits="360" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="119" hits="18" branch="false"/>
+						<line number="122" hits="1080" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="123" hits="720" branch="false"/>
+						<line number="127" hits="720" branch="false"/>
+						<line number="128" hits="720" branch="false"/>
+						<line number="130" hits="720" branch="false"/>
+						<line number="131" hits="720" branch="false"/>
+						<line number="133" hits="360" branch="false"/>
+						<line number="145" hits="1116" branch="false"/>
+						<line number="146" hits="1116" branch="false"/>
+						<line number="159" hits="3312" branch="false"/>
+						<line number="160" hits="3312" branch="false"/>
+						<line number="170" hits="6660" branch="false"/>
+						<line number="173" hits="6660" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="174" hits="4572" branch="false"/>
+						<line number="178" hits="6660" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="179" hits="72" branch="false"/>
+						<line number="182" hits="6660" branch="false"/>
+						<line number="184" hits="6660" branch="false"/>
+						<line number="192" hits="0" branch="false"/>
+						<line number="196" hits="0" branch="false"/>
+						<line number="197" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="199" hits="0" branch="false"/>
+						<line number="200" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="202" hits="0" branch="false"/>
+						<line number="204" hits="0" branch="false"/>
+						<line number="205" hits="0" branch="false"/>
+						<line number="214" hits="18" branch="false"/>
+						<line number="223" hits="1386" branch="false"/>
+						<line number="233" hits="8496" branch="false"/>
+						<line number="236" hits="8496" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="237" hits="756" branch="false"/>
+						<line number="240" hits="7740" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="241" hits="1350" branch="false"/>
+						<line number="245" hits="6390" branch="false"/>
+						<line number="248" hits="8496" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="262" hits="12186" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="263" hits="774" branch="false"/>
+						<line number="266" hits="11412" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="267" hits="1476" branch="false"/>
+						<line number="271" hits="9936" branch="false"/>
+						<line number="283" hits="4608" branch="false"/>
+						<line number="291" hits="0" branch="false"/>
+						<line number="293" hits="0" branch="false"/>
+						<line number="294" hits="0" branch="false"/>
+						<line number="295" hits="0" branch="false"/>
+						<line number="296" hits="0" branch="false"/>
+						<line number="297" hits="0" branch="false"/>
+						<line number="299" hits="0" branch="false"/>
+					</lines>
+				</class>
+				<class name="org.apache.commons.cli.ParseException" filename="org/apache/commons/cli/ParseException.java" line-rate="1.0" branch-rate="1.0" complexity="1.0">
+					<methods>
+						<method name="&lt;init&gt;" signature="(Ljava/lang/String;)V" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="82" hits="180" branch="false"/>
+								<line number="83" hits="180" branch="false"/>
+							</lines>
+						</method>
+					</methods>
+					<lines>
+						<line number="82" hits="180" branch="false"/>
+						<line number="83" hits="180" branch="false"/>
+					</lines>
+				</class>
+				<class name="org.apache.commons.cli.Parser" filename="org/apache/commons/cli/Parser.java" line-rate="0.9852941176470589" branch-rate="0.9565217391304348" complexity="5.0">
+					<methods>
+						<method name="&lt;init&gt;" signature="()V" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="77" hits="1242" branch="false"/>
+							</lines>
+						</method>
+						<method name="checkRequiredOptions" signature="()V" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="203" hits="1260" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="204" hits="54" branch="false"/>
+								<line number="205" hits="54" branch="false"/>
+								<line number="208" hits="108" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="209" hits="54" branch="false"/>
+								<line number="212" hits="54" branch="false"/>
+								<line number="214" hits="1206" branch="false"/>
+							</lines>
+						</method>
+						<method name="parse" signature="(Lorg/apache/commons/cli/Options;[Ljava/lang/String;)Lorg/apache/commons/cli/CommandLine;" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="115" hits="1242" branch="false"/>
+							</lines>
+						</method>
+						<method name="parse" signature="(Lorg/apache/commons/cli/Options;[Ljava/lang/String;Z)Lorg/apache/commons/cli/CommandLine;" line-rate="0.967741935483871" branch-rate="0.9090909090909091">
+							<lines>
+								<line number="136" hits="1386" branch="false"/>
+								<line number="137" hits="1386" branch="false"/>
+								<line number="138" hits="1386" branch="false"/>
+								<line number="140" hits="1386" branch="false"/>
+								<line number="142" hits="1386" branch="false"/>
+								<line number="144" hits="1386" branch="false"/>
+								<line number="147" hits="6588" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="148" hits="5328" branch="false"/>
+								<line number="151" hits="5328" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="152" hits="90" branch="false"/>
+								<line number="155" hits="5238" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="156" hits="36" branch="true" condition-coverage="50% (1/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+									</conditions>
+								</line>
+								<line number="157" hits="0" branch="false"/>
+								<line number="159" hits="36" branch="false"/>
+								<line number="163" hits="5202" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="164" hits="4428" branch="true" condition-coverage="100% (4/4)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+										<condition number="1" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="165" hits="18" branch="false"/>
+								<line number="166" hits="18" branch="false"/>
+								<line number="168" hits="4410" branch="false"/>
+								<line number="173" hits="774" branch="false"/>
+								<line number="174" hits="774" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="175" hits="54" branch="false"/>
+								<line number="180" hits="5202" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="181" hits="486" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="182" hits="324" branch="false"/>
+								<line number="184" hits="324" branch="true" condition-coverage="50% (1/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+									</conditions>
+								</line>
+								<line number="185" hits="324" branch="false"/>
+								<line number="187" hits="324" branch="false"/>
+								<line number="189" hits="5202" branch="false"/>
+								<line number="190" hits="1260" branch="false"/>
+								<line number="191" hits="1206" branch="false"/>
+							</lines>
+						</method>
+						<method name="processArgs" signature="(Lorg/apache/commons/cli/Option;Ljava/util/ListIterator;)V" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="228" hits="5310" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="229" hits="4608" branch="false"/>
+								<line number="232" hits="4608" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="233" hits="1602" branch="false"/>
+								<line number="234" hits="1602" branch="false"/>
+								<line number="237" hits="3006" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="238" hits="252" branch="false"/>
+								<line number="239" hits="252" branch="false"/>
+								<line number="241" hits="2754" branch="false"/>
+								<line number="243" hits="2556" branch="true" condition-coverage="100% (4/4)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+										<condition number="1" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="244" hits="54" branch="false"/>
+								<line number="247" hits="2502" branch="false"/>
+							</lines>
+						</method>
+						<method name="processOption" signature="(Ljava/lang/String;Ljava/util/ListIterator;)V" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="261" hits="4410" branch="false"/>
+								<line number="263" hits="4410" branch="false"/>
+								<line number="266" hits="4410" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="267" hits="36" branch="false"/>
+								<line number="270" hits="4374" branch="false"/>
+								<line number="275" hits="4374" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="276" hits="54" branch="false"/>
+								<line number="281" hits="4374" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="282" hits="234" branch="false"/>
+								<line number="283" hits="234" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="284" hits="36" branch="false"/>
+								<line number="286" hits="234" branch="false"/>
+								<line number="290" hits="4338" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="291" hits="2556" branch="false"/>
+								<line number="295" hits="4284" branch="false"/>
+								<line number="296" hits="4284" branch="false"/>
+							</lines>
+						</method>
+					</methods>
+					<lines>
+						<line number="77" hits="1242" branch="false"/>
+						<line number="115" hits="1242" branch="false"/>
+						<line number="136" hits="1386" branch="false"/>
+						<line number="137" hits="1386" branch="false"/>
+						<line number="138" hits="1386" branch="false"/>
+						<line number="140" hits="1386" branch="false"/>
+						<line number="142" hits="1386" branch="false"/>
+						<line number="144" hits="1386" branch="false"/>
+						<line number="147" hits="6588" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="148" hits="5328" branch="false"/>
+						<line number="151" hits="5328" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="152" hits="90" branch="false"/>
+						<line number="155" hits="5238" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="156" hits="36" branch="true" condition-coverage="50% (1/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+							</conditions>
+						</line>
+						<line number="157" hits="0" branch="false"/>
+						<line number="159" hits="36" branch="false"/>
+						<line number="163" hits="5202" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="164" hits="4428" branch="true" condition-coverage="100% (4/4)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+								<condition number="1" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="165" hits="18" branch="false"/>
+						<line number="166" hits="18" branch="false"/>
+						<line number="168" hits="4410" branch="false"/>
+						<line number="173" hits="774" branch="false"/>
+						<line number="174" hits="774" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="175" hits="54" branch="false"/>
+						<line number="180" hits="5202" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="181" hits="486" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="182" hits="324" branch="false"/>
+						<line number="184" hits="324" branch="true" condition-coverage="50% (1/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+							</conditions>
+						</line>
+						<line number="185" hits="324" branch="false"/>
+						<line number="187" hits="324" branch="false"/>
+						<line number="189" hits="5202" branch="false"/>
+						<line number="190" hits="1260" branch="false"/>
+						<line number="191" hits="1206" branch="false"/>
+						<line number="203" hits="1260" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="204" hits="54" branch="false"/>
+						<line number="205" hits="54" branch="false"/>
+						<line number="208" hits="108" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="209" hits="54" branch="false"/>
+						<line number="212" hits="54" branch="false"/>
+						<line number="214" hits="1206" branch="false"/>
+						<line number="228" hits="5310" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="229" hits="4608" branch="false"/>
+						<line number="232" hits="4608" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="233" hits="1602" branch="false"/>
+						<line number="234" hits="1602" branch="false"/>
+						<line number="237" hits="3006" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="238" hits="252" branch="false"/>
+						<line number="239" hits="252" branch="false"/>
+						<line number="241" hits="2754" branch="false"/>
+						<line number="243" hits="2556" branch="true" condition-coverage="100% (4/4)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+								<condition number="1" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="244" hits="54" branch="false"/>
+						<line number="247" hits="2502" branch="false"/>
+						<line number="261" hits="4410" branch="false"/>
+						<line number="263" hits="4410" branch="false"/>
+						<line number="266" hits="4410" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="267" hits="36" branch="false"/>
+						<line number="270" hits="4374" branch="false"/>
+						<line number="275" hits="4374" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="276" hits="54" branch="false"/>
+						<line number="281" hits="4374" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="282" hits="234" branch="false"/>
+						<line number="283" hits="234" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="284" hits="36" branch="false"/>
+						<line number="286" hits="234" branch="false"/>
+						<line number="290" hits="4338" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="291" hits="2556" branch="false"/>
+						<line number="295" hits="4284" branch="false"/>
+						<line number="296" hits="4284" branch="false"/>
+					</lines>
+				</class>
+				<class name="org.apache.commons.cli.PatternOptionBuilder" filename="org/apache/commons/cli/PatternOptionBuilder.java" line-rate="0.8867924528301887" branch-rate="0.8" complexity="9.333333333333334">
+					<methods>
+						<method name="&lt;clinit&gt;" signature="()V" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="75" hits="18" branch="false"/>
+								<line number="78" hits="18" branch="false"/>
+								<line number="81" hits="18" branch="false"/>
+								<line number="84" hits="18" branch="false"/>
+								<line number="87" hits="18" branch="false"/>
+								<line number="93" hits="18" branch="false"/>
+								<line number="97" hits="18" branch="false"/>
+								<line number="100" hits="18" branch="false"/>
+								<line number="103" hits="18" branch="false"/>
+							</lines>
+						</method>
+						<method name="&lt;init&gt;" signature="()V" line-rate="0.0" branch-rate="1.0">
+							<lines>
+								<line number="71" hits="0" branch="false"/>
+							</lines>
+						</method>
+						<method name="getValueClass" signature="(C)Ljava/lang/Object;" line-rate="0.7894736842105263" branch-rate="0.7777777777777778">
+							<lines>
+								<line number="113" hits="108" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="114" hits="18" branch="false"/>
+								<line number="115" hits="90" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="116" hits="18" branch="false"/>
+								<line number="117" hits="72" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="118" hits="18" branch="false"/>
+								<line number="119" hits="54" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="120" hits="18" branch="false"/>
+								<line number="121" hits="36" branch="true" condition-coverage="50% (1/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+									</conditions>
+								</line>
+								<line number="122" hits="0" branch="false"/>
+								<line number="123" hits="36" branch="true" condition-coverage="50% (1/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+									</conditions>
+								</line>
+								<line number="124" hits="0" branch="false"/>
+								<line number="125" hits="36" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="126" hits="18" branch="false"/>
+								<line number="127" hits="18" branch="true" condition-coverage="50% (1/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+									</conditions>
+								</line>
+								<line number="128" hits="0" branch="false"/>
+								<line number="129" hits="18" branch="true" condition-coverage="50% (1/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+									</conditions>
+								</line>
+								<line number="130" hits="18" branch="false"/>
+								<line number="132" hits="0" branch="false"/>
+							</lines>
+						</method>
+						<method name="isValueCode" signature="(C)Z" line-rate="1.0" branch-rate="0.8333333333333334">
+							<lines>
+								<line number="144" hits="252" branch="true" condition-coverage="83% (15/18)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+										<condition number="1" type="jump" coverage="100%"/>
+										<condition number="2" type="jump" coverage="100%"/>
+										<condition number="3" type="jump" coverage="100%"/>
+										<condition number="4" type="jump" coverage="50%"/>
+										<condition number="5" type="jump" coverage="50%"/>
+										<condition number="6" type="jump" coverage="100%"/>
+										<condition number="7" type="jump" coverage="50%"/>
+										<condition number="8" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="153" hits="144" branch="false"/>
+								<line number="155" hits="108" branch="false"/>
+							</lines>
+						</method>
+						<method name="parsePattern" signature="(Ljava/lang/String;)Lorg/apache/commons/cli/Options;" line-rate="0.9523809523809523" branch-rate="0.7857142857142857">
+							<lines>
+								<line number="167" hits="18" branch="false"/>
+								<line number="169" hits="18" branch="false"/>
+								<line number="170" hits="18" branch="false"/>
+								<line number="171" hits="18" branch="false"/>
+								<line number="172" hits="18" branch="false"/>
+								<line number="174" hits="18" branch="false"/>
+								<line number="176" hits="270" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="177" hits="252" branch="false"/>
+								<line number="181" hits="252" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="182" hits="144" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="184" hits="126" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="186" hits="126" branch="false"/>
+								<line number="187" hits="126" branch="false"/>
+								<line number="188" hits="126" branch="false"/>
+								<line number="190" hits="144" branch="false"/>
+								<line number="191" hits="108" branch="true" condition-coverage="50% (1/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+									</conditions>
+								</line>
+								<line number="192" hits="0" branch="false"/>
+								<line number="194" hits="108" branch="false"/>
+								<line number="198" hits="18" branch="true" condition-coverage="50% (1/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+									</conditions>
+								</line>
+								<line number="200" hits="18" branch="true" condition-coverage="50% (1/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+									</conditions>
+								</line>
+								<line number="204" hits="18" branch="false"/>
+							</lines>
+						</method>
+					</methods>
+					<lines>
+						<line number="71" hits="0" branch="false"/>
+						<line number="75" hits="18" branch="false"/>
+						<line number="78" hits="18" branch="false"/>
+						<line number="81" hits="18" branch="false"/>
+						<line number="84" hits="18" branch="false"/>
+						<line number="87" hits="18" branch="false"/>
+						<line number="93" hits="18" branch="false"/>
+						<line number="97" hits="18" branch="false"/>
+						<line number="100" hits="18" branch="false"/>
+						<line number="103" hits="18" branch="false"/>
+						<line number="113" hits="108" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="114" hits="18" branch="false"/>
+						<line number="115" hits="90" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="116" hits="18" branch="false"/>
+						<line number="117" hits="72" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="118" hits="18" branch="false"/>
+						<line number="119" hits="54" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="120" hits="18" branch="false"/>
+						<line number="121" hits="36" branch="true" condition-coverage="50% (1/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+							</conditions>
+						</line>
+						<line number="122" hits="0" branch="false"/>
+						<line number="123" hits="36" branch="true" condition-coverage="50% (1/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+							</conditions>
+						</line>
+						<line number="124" hits="0" branch="false"/>
+						<line number="125" hits="36" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="126" hits="18" branch="false"/>
+						<line number="127" hits="18" branch="true" condition-coverage="50% (1/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+							</conditions>
+						</line>
+						<line number="128" hits="0" branch="false"/>
+						<line number="129" hits="18" branch="true" condition-coverage="50% (1/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+							</conditions>
+						</line>
+						<line number="130" hits="18" branch="false"/>
+						<line number="132" hits="0" branch="false"/>
+						<line number="144" hits="252" branch="true" condition-coverage="83% (15/18)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+								<condition number="1" type="jump" coverage="100%"/>
+								<condition number="2" type="jump" coverage="100%"/>
+								<condition number="3" type="jump" coverage="100%"/>
+								<condition number="4" type="jump" coverage="50%"/>
+								<condition number="5" type="jump" coverage="50%"/>
+								<condition number="6" type="jump" coverage="100%"/>
+								<condition number="7" type="jump" coverage="50%"/>
+								<condition number="8" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="153" hits="144" branch="false"/>
+						<line number="155" hits="108" branch="false"/>
+						<line number="167" hits="18" branch="false"/>
+						<line number="169" hits="18" branch="false"/>
+						<line number="170" hits="18" branch="false"/>
+						<line number="171" hits="18" branch="false"/>
+						<line number="172" hits="18" branch="false"/>
+						<line number="174" hits="18" branch="false"/>
+						<line number="176" hits="270" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="177" hits="252" branch="false"/>
+						<line number="181" hits="252" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="182" hits="144" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="184" hits="126" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="186" hits="126" branch="false"/>
+						<line number="187" hits="126" branch="false"/>
+						<line number="188" hits="126" branch="false"/>
+						<line number="190" hits="144" branch="false"/>
+						<line number="191" hits="108" branch="true" condition-coverage="50% (1/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+							</conditions>
+						</line>
+						<line number="192" hits="0" branch="false"/>
+						<line number="194" hits="108" branch="false"/>
+						<line number="198" hits="18" branch="true" condition-coverage="50% (1/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+							</conditions>
+						</line>
+						<line number="200" hits="18" branch="true" condition-coverage="50% (1/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+							</conditions>
+						</line>
+						<line number="204" hits="18" branch="false"/>
+					</lines>
+				</class>
+				<class name="org.apache.commons.cli.PosixParser" filename="org/apache/commons/cli/PosixParser.java" line-rate="0.8787878787878788" branch-rate="0.775" complexity="3.5714285714285716">
+					<methods>
+						<method name="&lt;init&gt;" signature="()V" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="77" hits="1026" branch="false"/>
+								<line number="79" hits="1026" branch="false"/>
+							</lines>
+						</method>
+						<method name="burstToken" signature="(Ljava/lang/String;Z)V" line-rate="0.9285714285714286" branch-rate="0.9">
+							<lines>
+								<line number="293" hits="630" branch="false"/>
+								<line number="295" hits="756" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="296" hits="738" branch="false"/>
+								<line number="297" hits="738" branch="false"/>
+								<line number="299" hits="738" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="300" hits="720" branch="false"/>
+								<line number="301" hits="720" branch="false"/>
+								<line number="302" hits="720" branch="true" condition-coverage="100% (4/4)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+										<condition number="1" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="303" hits="612" branch="false"/>
+								<line number="304" hits="612" branch="false"/>
+								<line number="306" hits="18" branch="true" condition-coverage="50% (1/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+									</conditions>
+								</line>
+								<line number="307" hits="0" branch="false"/>
+								<line number="309" hits="18" branch="false"/>
+								<line number="312" hits="630" branch="false"/>
+							</lines>
+						</method>
+						<method name="flatten" signature="(Lorg/apache/commons/cli/Options;[Ljava/lang/String;Z)[Ljava/lang/String;" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="144" hits="1116" branch="false"/>
+								<line number="145" hits="1116" branch="false"/>
+								<line number="148" hits="1116" branch="false"/>
+								<line number="149" hits="1116" branch="false"/>
+								<line number="152" hits="7776" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="154" hits="6660" branch="false"/>
+								<line number="157" hits="6660" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="158" hits="1008" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="159" hits="18" branch="false"/>
+								<line number="160" hits="18" branch="false"/>
+								<line number="163" hits="990" branch="false"/>
+								<line number="167" hits="5652" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="168" hits="36" branch="false"/>
+								<line number="169" hits="5616" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="170" hits="2916" branch="false"/>
+								<line number="171" hits="2916" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="172" hits="2286" branch="false"/>
+								<line number="176" hits="630" branch="false"/>
+								<line number="178" hits="2916" branch="false"/>
+								<line number="179" hits="2700" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="180" hits="54" branch="false"/>
+								<line number="182" hits="2646" branch="false"/>
+								<line number="186" hits="6660" branch="false"/>
+								<line number="189" hits="1116" branch="false"/>
+							</lines>
+						</method>
+						<method name="gobble" signature="(Ljava/util/Iterator;)V" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="198" hits="6660" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="199" hits="126" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="200" hits="72" branch="false"/>
+								<line number="203" hits="6660" branch="false"/>
+							</lines>
+						</method>
+						<method name="init" signature="()V" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="96" hits="1116" branch="false"/>
+								<line number="97" hits="1116" branch="false"/>
+								<line number="98" hits="1116" branch="false"/>
+								<line number="99" hits="1116" branch="false"/>
+							</lines>
+						</method>
+						<method name="process" signature="(Ljava/lang/String;)V" line-rate="0.5" branch-rate="0.375">
+							<lines>
+								<line number="221" hits="54" branch="true" condition-coverage="75% (3/4)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+										<condition number="1" type="jump" coverage="50%"/>
+									</conditions>
+								</line>
+								<line number="222" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="223" hits="0" branch="false"/>
+								<line number="224" hits="0" branch="false"/>
+								<line number="225" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="226" hits="0" branch="false"/>
+								<line number="229" hits="54" branch="false"/>
+								<line number="230" hits="54" branch="false"/>
+								<line number="231" hits="54" branch="false"/>
+								<line number="233" hits="54" branch="false"/>
+							</lines>
+						</method>
+						<method name="processOptionToken" signature="(Ljava/lang/String;Z)V" line-rate="0.6666666666666666" branch-rate="0.25">
+							<lines>
+								<line number="258" hits="2286" branch="true" condition-coverage="50% (1/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+									</conditions>
+								</line>
+								<line number="259" hits="2286" branch="false"/>
+								<line number="260" hits="2286" branch="false"/>
+								<line number="261" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="262" hits="0" branch="false"/>
+								<line number="264" hits="2286" branch="false"/>
+							</lines>
+						</method>
+						<method name="processSingleHyphen" signature="(Ljava/lang/String;)V" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="242" hits="36" branch="false"/>
+								<line number="243" hits="36" branch="false"/>
+							</lines>
+						</method>
+					</methods>
+					<lines>
+						<line number="77" hits="1026" branch="false"/>
+						<line number="79" hits="1026" branch="false"/>
+						<line number="96" hits="1116" branch="false"/>
+						<line number="97" hits="1116" branch="false"/>
+						<line number="98" hits="1116" branch="false"/>
+						<line number="99" hits="1116" branch="false"/>
+						<line number="144" hits="1116" branch="false"/>
+						<line number="145" hits="1116" branch="false"/>
+						<line number="148" hits="1116" branch="false"/>
+						<line number="149" hits="1116" branch="false"/>
+						<line number="152" hits="7776" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="154" hits="6660" branch="false"/>
+						<line number="157" hits="6660" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="158" hits="1008" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="159" hits="18" branch="false"/>
+						<line number="160" hits="18" branch="false"/>
+						<line number="163" hits="990" branch="false"/>
+						<line number="167" hits="5652" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="168" hits="36" branch="false"/>
+						<line number="169" hits="5616" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="170" hits="2916" branch="false"/>
+						<line number="171" hits="2916" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="172" hits="2286" branch="false"/>
+						<line number="176" hits="630" branch="false"/>
+						<line number="178" hits="2916" branch="false"/>
+						<line number="179" hits="2700" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="180" hits="54" branch="false"/>
+						<line number="182" hits="2646" branch="false"/>
+						<line number="186" hits="6660" branch="false"/>
+						<line number="189" hits="1116" branch="false"/>
+						<line number="198" hits="6660" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="199" hits="126" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="200" hits="72" branch="false"/>
+						<line number="203" hits="6660" branch="false"/>
+						<line number="221" hits="54" branch="true" condition-coverage="75% (3/4)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+								<condition number="1" type="jump" coverage="50%"/>
+							</conditions>
+						</line>
+						<line number="222" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="223" hits="0" branch="false"/>
+						<line number="224" hits="0" branch="false"/>
+						<line number="225" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="226" hits="0" branch="false"/>
+						<line number="229" hits="54" branch="false"/>
+						<line number="230" hits="54" branch="false"/>
+						<line number="231" hits="54" branch="false"/>
+						<line number="233" hits="54" branch="false"/>
+						<line number="242" hits="36" branch="false"/>
+						<line number="243" hits="36" branch="false"/>
+						<line number="258" hits="2286" branch="true" condition-coverage="50% (1/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+							</conditions>
+						</line>
+						<line number="259" hits="2286" branch="false"/>
+						<line number="260" hits="2286" branch="false"/>
+						<line number="261" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="262" hits="0" branch="false"/>
+						<line number="264" hits="2286" branch="false"/>
+						<line number="293" hits="630" branch="false"/>
+						<line number="295" hits="756" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="296" hits="738" branch="false"/>
+						<line number="297" hits="738" branch="false"/>
+						<line number="299" hits="738" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="300" hits="720" branch="false"/>
+						<line number="301" hits="720" branch="false"/>
+						<line number="302" hits="720" branch="true" condition-coverage="100% (4/4)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+								<condition number="1" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="303" hits="612" branch="false"/>
+						<line number="304" hits="612" branch="false"/>
+						<line number="306" hits="18" branch="true" condition-coverage="50% (1/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+							</conditions>
+						</line>
+						<line number="307" hits="0" branch="false"/>
+						<line number="309" hits="18" branch="false"/>
+						<line number="312" hits="630" branch="false"/>
+					</lines>
+				</class>
+				<class name="org.apache.commons.cli.TypeHandler" filename="org/apache/commons/cli/TypeHandler.java" line-rate="0.4909090909090909" branch-rate="0.7" complexity="4.444444444444445">
+					<methods>
+						<method name="&lt;init&gt;" signature="()V" line-rate="0.0" branch-rate="1.0">
+							<lines>
+								<line number="81" hits="0" branch="false"/>
+							</lines>
+						</method>
+						<method name="createClass" signature="(Ljava/lang/String;)Ljava/lang/Class;" line-rate="0.25" branch-rate="1.0">
+							<lines>
+								<line number="191" hits="36" branch="false"/>
+								<line number="192" hits="0" branch="false"/>
+								<line number="193" hits="0" branch="false"/>
+								<line number="194" hits="0" branch="false"/>
+							</lines>
+						</method>
+						<method name="createDate" signature="(Ljava/lang/String;)Ljava/util/Date;" line-rate="0.0" branch-rate="0.0">
+							<lines>
+								<line number="207" hits="0" branch="false"/>
+								<line number="208" hits="0" branch="true" condition-coverage="0% (0/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="0%"/>
+									</conditions>
+								</line>
+								<line number="209" hits="0" branch="false"/>
+								<line number="211" hits="0" branch="false"/>
+							</lines>
+						</method>
+						<method name="createFile" signature="(Ljava/lang/String;)Ljava/io/File;" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="239" hits="36" branch="false"/>
+							</lines>
+						</method>
+						<method name="createFiles" signature="(Ljava/lang/String;)[Ljava/io/File;" line-rate="0.0" branch-rate="1.0">
+							<lines>
+								<line number="252" hits="0" branch="false"/>
+							</lines>
+						</method>
+						<method name="createNumber" signature="(Ljava/lang/String;)Ljava/lang/Number;" line-rate="0.25" branch-rate="1.0">
+							<lines>
+								<line number="175" hits="36" branch="false"/>
+								<line number="176" hits="0" branch="false"/>
+								<line number="177" hits="0" branch="false"/>
+								<line number="178" hits="0" branch="false"/>
+							</lines>
+						</method>
+						<method name="createObject" signature="(Ljava/lang/String;)Ljava/lang/Object;" line-rate="0.4375" branch-rate="1.0">
+							<lines>
+								<line number="138" hits="36" branch="false"/>
+								<line number="140" hits="36" branch="false"/>
+								<line number="141" hits="0" branch="false"/>
+								<line number="142" hits="0" branch="false"/>
+								<line number="143" hits="0" branch="false"/>
+								<line number="144" hits="36" branch="false"/>
+								<line number="146" hits="36" branch="false"/>
+								<line number="149" hits="36" branch="false"/>
+								<line number="150" hits="0" branch="false"/>
+								<line number="151" hits="0" branch="false"/>
+								<line number="153" hits="0" branch="false"/>
+								<line number="154" hits="0" branch="false"/>
+								<line number="155" hits="0" branch="false"/>
+								<line number="157" hits="0" branch="false"/>
+								<line number="158" hits="36" branch="false"/>
+								<line number="160" hits="36" branch="false"/>
+							</lines>
+						</method>
+						<method name="createURL" signature="(Ljava/lang/String;)Ljava/net/URL;" line-rate="0.25" branch-rate="1.0">
+							<lines>
+								<line number="224" hits="36" branch="false"/>
+								<line number="225" hits="0" branch="false"/>
+								<line number="226" hits="0" branch="false"/>
+								<line number="227" hits="0" branch="false"/>
+							</lines>
+						</method>
+						<method name="createValue" signature="(Ljava/lang/String;Ljava/lang/Class;)Ljava/lang/Object;" line-rate="0.7894736842105263" branch-rate="0.7777777777777778">
+							<lines>
+								<line number="107" hits="216" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="108" hits="36" branch="false"/>
+								<line number="109" hits="180" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="110" hits="36" branch="false"/>
+								<line number="111" hits="144" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="112" hits="36" branch="false"/>
+								<line number="113" hits="108" branch="true" condition-coverage="50% (1/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+									</conditions>
+								</line>
+								<line number="114" hits="0" branch="false"/>
+								<line number="115" hits="108" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="116" hits="36" branch="false"/>
+								<line number="117" hits="72" branch="true" condition-coverage="100% (2/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="100%"/>
+									</conditions>
+								</line>
+								<line number="118" hits="36" branch="false"/>
+								<line number="119" hits="36" branch="true" condition-coverage="50% (1/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+									</conditions>
+								</line>
+								<line number="120" hits="0" branch="false"/>
+								<line number="121" hits="36" branch="true" condition-coverage="50% (1/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+									</conditions>
+								</line>
+								<line number="122" hits="0" branch="false"/>
+								<line number="123" hits="36" branch="true" condition-coverage="50% (1/2)">
+									<conditions>
+										<condition number="0" type="jump" coverage="50%"/>
+									</conditions>
+								</line>
+								<line number="124" hits="36" branch="false"/>
+								<line number="126" hits="0" branch="false"/>
+							</lines>
+						</method>
+						<method name="createValue" signature="(Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="93" hits="216" branch="false"/>
+							</lines>
+						</method>
+					</methods>
+					<lines>
+						<line number="81" hits="0" branch="false"/>
+						<line number="93" hits="216" branch="false"/>
+						<line number="107" hits="216" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="108" hits="36" branch="false"/>
+						<line number="109" hits="180" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="110" hits="36" branch="false"/>
+						<line number="111" hits="144" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="112" hits="36" branch="false"/>
+						<line number="113" hits="108" branch="true" condition-coverage="50% (1/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+							</conditions>
+						</line>
+						<line number="114" hits="0" branch="false"/>
+						<line number="115" hits="108" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="116" hits="36" branch="false"/>
+						<line number="117" hits="72" branch="true" condition-coverage="100% (2/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="100%"/>
+							</conditions>
+						</line>
+						<line number="118" hits="36" branch="false"/>
+						<line number="119" hits="36" branch="true" condition-coverage="50% (1/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+							</conditions>
+						</line>
+						<line number="120" hits="0" branch="false"/>
+						<line number="121" hits="36" branch="true" condition-coverage="50% (1/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+							</conditions>
+						</line>
+						<line number="122" hits="0" branch="false"/>
+						<line number="123" hits="36" branch="true" condition-coverage="50% (1/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="50%"/>
+							</conditions>
+						</line>
+						<line number="124" hits="36" branch="false"/>
+						<line number="126" hits="0" branch="false"/>
+						<line number="138" hits="36" branch="false"/>
+						<line number="140" hits="36" branch="false"/>
+						<line number="141" hits="0" branch="false"/>
+						<line number="142" hits="0" branch="false"/>
+						<line number="143" hits="0" branch="false"/>
+						<line number="144" hits="36" branch="false"/>
+						<line number="146" hits="36" branch="false"/>
+						<line number="149" hits="36" branch="false"/>
+						<line number="150" hits="0" branch="false"/>
+						<line number="151" hits="0" branch="false"/>
+						<line number="153" hits="0" branch="false"/>
+						<line number="154" hits="0" branch="false"/>
+						<line number="155" hits="0" branch="false"/>
+						<line number="157" hits="0" branch="false"/>
+						<line number="158" hits="36" branch="false"/>
+						<line number="160" hits="36" branch="false"/>
+						<line number="175" hits="36" branch="false"/>
+						<line number="176" hits="0" branch="false"/>
+						<line number="177" hits="0" branch="false"/>
+						<line number="178" hits="0" branch="false"/>
+						<line number="191" hits="36" branch="false"/>
+						<line number="192" hits="0" branch="false"/>
+						<line number="193" hits="0" branch="false"/>
+						<line number="194" hits="0" branch="false"/>
+						<line number="207" hits="0" branch="false"/>
+						<line number="208" hits="0" branch="true" condition-coverage="0% (0/2)">
+							<conditions>
+								<condition number="0" type="jump" coverage="0%"/>
+							</conditions>
+						</line>
+						<line number="209" hits="0" branch="false"/>
+						<line number="211" hits="0" branch="false"/>
+						<line number="224" hits="36" branch="false"/>
+						<line number="225" hits="0" branch="false"/>
+						<line number="226" hits="0" branch="false"/>
+						<line number="227" hits="0" branch="false"/>
+						<line number="239" hits="36" branch="false"/>
+						<line number="252" hits="0" branch="false"/>
+					</lines>
+				</class>
+				<class name="org.apache.commons.cli.UnrecognizedOptionException" filename="org/apache/commons/cli/UnrecognizedOptionException.java" line-rate="1.0" branch-rate="1.0" complexity="1.0">
+					<methods>
+						<method name="&lt;init&gt;" signature="(Ljava/lang/String;)V" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="85" hits="36" branch="false"/>
+								<line number="86" hits="36" branch="false"/>
+							</lines>
+						</method>
+					</methods>
+					<lines>
+						<line number="85" hits="36" branch="false"/>
+						<line number="86" hits="36" branch="false"/>
+					</lines>
+				</class>
+			</classes>
+		</package>
+	</packages>
+</coverage>

--- a/src/test/resources/cobertura-python.xml
+++ b/src/test/resources/cobertura-python.xml
@@ -1,0 +1,40 @@
+<coverage branch-rate="0.8337" branches-covered="396" branches-valid="475" complexity="0"
+          line-rate="0.9448" lines-covered="2514" lines-valid="2661" timestamp="1674553788337"
+          version="7.0.5">
+  <sources>
+    <source>
+      /home/user/dev/python/package
+    </source>
+  </sources>
+  <packages>
+    <package branch-rate="0.6759" complexity="0" line-rate="0.8305" name=".">
+      <classes>
+        <class branch-rate="1" complexity="0" filename="__init__.py" line-rate="1"
+               name="__init__.py">
+          <methods />
+          <lines>
+            <line hits="1" number="6" />
+            <line hits="1" number="8" />
+            <line hits="1" number="9" />
+            <line hits="1" number="10" />
+            <line hits="1" number="11" />
+            <line hits="1" number="13" />
+            <line hits="1" number="16" />
+            <line hits="1" number="25" />
+            <line branch="true" condition-coverage="100% (2/2)" hits="1" number="41" />
+            <line hits="1" number="42" />
+            <line hits="1" number="46" />
+            <line hits="1" number="48" />
+            <line branch="true" condition-coverage="100% (2/2)" hits="1" number="49" />
+            <line hits="1" number="50" />
+            <line hits="1" number="54" />
+            <line hits="1" number="55" />
+            <line hits="1" number="56" />
+            <line hits="1" number="57" />
+            <line hits="1" number="60" />
+          </lines>
+        </class>
+      </classes>
+    </package>
+  </packages>
+</coverage>


### PR DESCRIPTION
Improve the existing parser so that the pull model can be used.

Also make sure that the paths are working correctly throughout the hierarchy (see https://github.com/jenkinsci/code-coverage-api-plugin/pull/547).